### PR TITLE
Fixed dropdown bug

### DIFF
--- a/pages/archive/index.js
+++ b/pages/archive/index.js
@@ -35,7 +35,7 @@ export default function EventList(props) {
 
 	return (
 		<ArchiveLayout>
-			<div className="relative z-20 -mt-2 flex w-full flex-col items-center justify-between md:w-5/6 md:flex-row">
+			<div className="relative z-10 -mt-2 flex w-full flex-col items-center justify-between md:w-5/6 md:flex-row">
 				<div className="relative z-20 mt-5 text-sm md:text-base">
 					An archive of WXYC&apos;s weekly specialty shows and events.{' '}
 					<a href="../page/programming" className="underline">
@@ -48,7 +48,7 @@ export default function EventList(props) {
 			</div>
 
 			{/* Desktop banner image */}
-			<div className="relative z-10 -mt-10 hidden md:block">
+			<div className="relative z-5 -mt-10 hidden md:block">
 				<Image src={photo} alt="A crowded dancefloor at a WXYC event." />
 			</div>
 


### PR DESCRIPTION
Desktop: Lowered z-index of filter element and banner image on archive page so that Listen dropdown link overlaps correctly