### PR TITLE
Consolidate safe description text extraction into shared utility

### DIFF
--- a/components/OrganizingArchive.js
+++ b/components/OrganizingArchive.js
@@ -46,3 +46,13 @@ export function generateStructuredData(groupedEvents) {
 
 	return structuredData
 }
+
+// Helper to safely extract description text from TinaCMS rich-text field
+export function getDescriptionText(description, maxLength = 75) {
+	try {
+		const text = description?.children?.[0]?.children?.[0]?.text
+		return text ? text.substring(0, maxLength) : ''
+	} catch {
+		return ''
+	}
+}

--- a/pages/archive/events.js
+++ b/pages/archive/events.js
@@ -3,6 +3,7 @@ import EventPreview from '../../components/EventPreview'
 import {
 	groupEventsByWeek,
 	generateStructuredData,
+	getDescriptionText,
 } from '../../components/OrganizingArchive'
 import ArchiveLayout from '../../components/ArchiveLayout'
 import React, {useState} from 'react'
@@ -59,10 +60,7 @@ const EventsCategoryPage = (props) => {
 														key={event.event.id}
 														title={event.event.title}
 														cover={event.event.cover}
-														subtitle={event.event.description.children[0].children[0].text.substring(
-															0,
-															75
-														)}
+														subtitle={getDescriptionText(event.event.description)}
 														slug={event.event._sys.filename}
 													/>
 												))}

--- a/pages/archive/index.js
+++ b/pages/archive/index.js
@@ -3,6 +3,7 @@ import {client} from '../../tina/__generated__/client'
 import {
 	groupEventsByWeek,
 	generateStructuredData,
+	getDescriptionText,
 } from '../../components/OrganizingArchive'
 // import LazyLoad from 'react-lazyload';
 import ArchiveDropdown from '../../components/DropdownArchive'
@@ -12,16 +13,6 @@ import mobilephoto from '/images/crowdmobile.jpeg'
 import Image from 'next/image'
 import React, {useState} from 'react'
 import SeeMoreButton from '../../components/SeeMoreButton'
-
-// Helper to safely extract description text from TinaCMS rich-text field
-const getDescriptionText = (description, maxLength = 75) => {
-	try {
-		const text = description?.children?.[0]?.children?.[0]?.text
-		return text ? text.substring(0, maxLength) : ''
-	} catch {
-		return ''
-	}
-}
 
 // archive home page
 export default function EventList(props) {

--- a/pages/archive/specialty-shows/[slug].js
+++ b/pages/archive/specialty-shows/[slug].js
@@ -3,20 +3,11 @@ import EventPreview from '../../../components/EventPreview'
 import {
 	groupEventsByWeek,
 	generateStructuredData,
+	getDescriptionText,
 } from '../../../components/OrganizingArchive'
 import ArchiveLayout from '../../../components/ArchiveLayout'
 import React, {useState} from 'react'
 import SeeMoreButton from '../../../components/SeeMoreButton'
-
-// Helper to safely extract description text from TinaCMS rich-text field
-const getDescriptionText = (description, maxLength = 75) => {
-	try {
-		const text = description?.children?.[0]?.children?.[0]?.text
-		return text ? text.substring(0, maxLength) : ''
-	} catch {
-		return ''
-	}
-}
 
 // filter archive by a specific specialty show
 const ArchiveCategoryPage = (props) => {

--- a/pages/archive/specialty-shows/index.js
+++ b/pages/archive/specialty-shows/index.js
@@ -3,6 +3,7 @@ import EventPreview from '../../../components/EventPreview'
 import {
 	groupEventsByWeek,
 	generateStructuredData,
+	getDescriptionText,
 } from '../../../components/OrganizingArchive'
 import Link from 'next/link'
 import ArchiveLayout from '../../../components/ArchiveLayout'
@@ -67,10 +68,7 @@ const SpecialtyShowsPage = (props) => {
 															id={event.event.id}
 															title={event.event.title}
 															cover={event.event.cover}
-															subtitle={event.event.description.children[0].children[0].text.substring(
-																0,
-																75
-															)}
+															subtitle={getDescriptionText(event.event.description)}
 															slug={event.event._sys.filename}
 														/>
 													</div>


### PR DESCRIPTION
## Summary
- Extract `getDescriptionText` helper to `components/OrganizingArchive.js` as a shared utility
- Update all 4 archive pages to use the shared function instead of duplicated local helpers or unsafe inline access
- Ensures consistent null-safe handling of TinaCMS rich-text description fields

## Changes
| File | Change |
|------|--------|
| `components/OrganizingArchive.js` | Add shared `getDescriptionText` helper |
| `pages/archive/index.js` | Use shared helper, remove local copy |
| `pages/archive/events.js` | Add import, replace unsafe access |
| `pages/archive/specialty-shows/index.js` | Add import, replace unsafe access |
| `pages/archive/specialty-shows/[slug].js` | Use shared helper, remove local copy |

## Test plan
- [ ] Verify archive pages render correctly with valid descriptions
- [ ] Verify pages don't crash when description content is missing or malformed