### PR TITLE
Fix fallback for static export in all dynamic routes

### DIFF
--- a/lib/staticPaths.js
+++ b/lib/staticPaths.js
@@ -1,0 +1,7 @@
+/**
+ * Fallback setting for getStaticPaths.
+ *
+ * Must be `false` for static export (output: 'export' in next.config.js)
+ * since there's no server to handle on-demand rendering.
+ */
+export const STATIC_FALLBACK = false

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -1,6 +1,7 @@
 import {TinaMarkdown} from 'tinacms/dist/rich-text'
 import {tinaField, useTina} from 'tinacms/dist/react'
 import {client} from '../tina/__generated__/client'
+import {STATIC_FALLBACK} from '../lib/staticPaths'
 
 //editable static pages (programming, contact, etc.)
 export default function Home(props) {
@@ -33,7 +34,7 @@ export const getStaticPaths = async () => {
 
 	return {
 		paths,
-		fallback: 'blocking',
+		fallback: STATIC_FALLBACK,
 	}
 }
 

--- a/pages/about/[slug].js
+++ b/pages/about/[slug].js
@@ -1,6 +1,7 @@
 import {TinaMarkdown} from 'tinacms/dist/rich-text'
 import {tinaField, useTina} from 'tinacms/dist/react'
 import {client} from '../../tina/__generated__/client'
+import {STATIC_FALLBACK} from '../../lib/staticPaths'
 import AboutLayout from '../../components/AboutLayout'
 
 //editable static pages within the about tab (mission and history)
@@ -33,7 +34,7 @@ export const getStaticPaths = async () => {
 
 	return {
 		paths,
-		fallback: 'blocking',
+		fallback: STATIC_FALLBACK,
 	}
 }
 

--- a/pages/archive/[slug].js
+++ b/pages/archive/[slug].js
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import ArchiveLayout from '../../components/ArchiveLayout'
 import {AiFillTag} from 'react-icons/ai'
 import Head from 'next/head'
+import {STATIC_FALLBACK} from '../../lib/staticPaths'
 
 // page for a specific specialty show after it's been opened
 const EventPage = (props) => {
@@ -91,7 +92,7 @@ export const getStaticPaths = async () => {
 
 	return {
 		paths,
-		fallback: 'blocking',
+		fallback: STATIC_FALLBACK,
 	}
 }
 

--- a/pages/archive/specialty-shows/[slug].js
+++ b/pages/archive/specialty-shows/[slug].js
@@ -7,6 +7,7 @@ import {
 import ArchiveLayout from '../../../components/ArchiveLayout'
 import React, {useState} from 'react'
 import SeeMoreButton from '../../../components/SeeMoreButton'
+import {STATIC_FALLBACK} from '../../../lib/staticPaths'
 
 // Helper to safely extract description text from TinaCMS rich-text field
 const getDescriptionText = (description, maxLength = 75) => {
@@ -106,7 +107,7 @@ export const getStaticPaths = async () => {
 
 	return {
 		paths,
-		fallback: 'blocking',
+		fallback: STATIC_FALLBACK,
 	}
 }
 

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -3,6 +3,7 @@ import {client} from '../../tina/__generated__/client'
 import {TinaMarkdown} from 'tinacms/dist/rich-text'
 import Link from 'next/link'
 import BlogLayout from '../../components/BlogLayout'
+import {STATIC_FALLBACK} from '../../lib/staticPaths'
 
 // const components = {
 // 	// google drive embedded iframe mp3
@@ -85,7 +86,7 @@ export const getStaticPaths = async () => {
 
 	return {
 		paths,
-		fallback: 'blocking',
+		fallback: STATIC_FALLBACK,
 	}
 }
 

--- a/pages/blog/category/[slug].js
+++ b/pages/blog/category/[slug].js
@@ -3,6 +3,7 @@ import PostPreview from '../../../components/PostPreview'
 import BlogLayout from '../../../components/BlogLayout'
 import SeeMoreButton from '../../../components/SeeMoreButton'
 import React, {useState} from 'react'
+import {STATIC_FALLBACK} from '../../../lib/staticPaths'
 
 // filtering bog by category (either artist interview, show review, or album review)
 const BlogCategoryPage = (props) => {
@@ -65,7 +66,7 @@ export const getStaticPaths = async () => {
 
 	return {
 		paths,
-		fallback: 'blocking',
+		fallback: STATIC_FALLBACK,
 	}
 }
 


### PR DESCRIPTION
## Problem

All dynamic route pages were using `fallback: 'blocking'` in `getStaticPaths`, which is incompatible with Next.js static export (`output: 'export'` in next.config.js).

The `'blocking'` fallback tells Next.js to server-render pages on-demand for paths not pre-generated at build time. However, with static export, there's no server — this was causing Tina errors in development mode.

## Solution

1. Add a `STATIC_FALLBACK` constant in `lib/staticPaths.js` that documents why this value must be `false` for static exports.

2. Update all dynamic route pages to use this constant:
   - `pages/[slug].js`
   - `pages/about/[slug].js`
   - `pages/archive/[slug].js`
   - `pages/archive/specialty-shows/[slug].js`
   - `pages/blog/[slug].js`
   - `pages/blog/category/[slug].js`

Using a constant ensures consistency across all pages and prevents this bug class in the future.

## Notes

This setting has been present since the files were first created (starting with commit 57005c1 from June 2023), so it was never compatible with static export — it just happened to work because builds succeeded and static files were served.