### PR TITLE
Update default font to Futura with Poppins fallback

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -209,7 +209,7 @@ const Header = () => {
 									89.3FM
 								</h1>
 								<div className="mt-2">
-									<h3 className="poppins mx-auto w-full text-center text-base md:mx-0  md:text-xl lg:text-base">
+									<h3 className="font-sans mx-auto w-full text-center text-base md:mx-0  md:text-xl lg:text-base">
 										UNC-Chapel Hill&apos;s student-run, freeform radio station
 									</h3>
 								</div>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,8 @@
 import React from 'react'
+import '@fontsource/poppins/400.css'
+import '@fontsource/poppins/500.css'
+import '@fontsource/poppins/600.css'
+import '@fontsource/poppins/700.css'
 import '/styles/globals.css'
 import {Layout} from '../components/Layout'
 import {PostHogProvider} from 'posthog-js/react'
@@ -39,7 +43,7 @@ const App = ({Component, pageProps}) => {
 		<PostHogProvider client={posthog}>
 			<LavaLiteBackground brightness={0.85} />
 			<div className="flex flex-col lg:items-center">
-				<div className="m-0 flex h-full w-full flex-col overflow-hidden bg-transparent font-poppins text-base text-white">
+				<div className="m-0 flex h-full w-full flex-col overflow-hidden bg-transparent font-sans text-base text-white">
 					<Layout>
 						<Component {...pageProps} />
 					</Layout>

--- a/pages/index.js
+++ b/pages/index.js
@@ -31,7 +31,7 @@ export default function Home(props) {
 									89.3FM
 								</h1>
 								<div className="mt-2">
-									<h3 className="poppins mx-auto w-full text-center text-base md:mx-0  md:text-xl lg:text-base">
+									<h3 className="font-sans mx-auto w-full text-center text-base md:mx-0  md:text-xl lg:text-base">
 										UNC-Chapel Hill&apos;s student-run, freeform radio station
 									</h3>
 								</div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
 	theme: {
 		extend: {
 			fontFamily: {
-				poppins: ['Poppins', 'sans-serif'],
+				sans: ['Futura', 'Futura-Medium', 'Poppins', 'Century Gothic', 'sans-serif'],
 				kallisto: ['kallisto', 'serif'],
 			},
 			objectFit: {


### PR DESCRIPTION
## Summary
- Sets Futura as the primary font with fallbacks to Poppins, Century Gothic, and system sans-serif
- Adds proper `@fontsource/poppins` imports so Poppins loads correctly as a fallback (it was installed but never imported)
- Updates Tailwind config and replaces `font-poppins` class with `font-sans` throughout