### PR TITLE
Fix PR builds to use TinaCMS local mode

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: 'pages'
+  group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -58,11 +58,13 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Run tests
         run: npm test
-      - name: Build TinaCMS
-        env:
-          TINA_PUBLIC_CLIENT_ID: ${{ secrets.TINA_PUBLIC_CLIENT_ID }}
-          TINA_TOKEN: ${{ secrets.TINA_TOKEN }}
-          SEARCH_TOKEN: ${{ secrets.SEARCH_TOKEN }}
-        run: npx tinacms build 
-      - name: Build with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next build
+      - name: Build with TinaCMS (local mode)
+        # Run in local mode so PR builds can access new content files
+        # that haven't been merged to main yet. Start the TinaCMS local
+        # server in the background, run Next.js build, then stop it.
+        run: |
+          npx tinacms dev &
+          TINA_PID=$!
+          sleep 10
+          npx next build
+          kill $TINA_PID || true


### PR DESCRIPTION
## Summary

PR builds were failing when adding new content files because TinaCMS was querying Tina Cloud, which doesn't have content from unmerged PRs.

This change:
- Runs TinaCMS dev server in background during Next.js build
- Uses PR-specific concurrency group to avoid conflicts with production deploys
- Allows PR builds to access new content files from the filesystem

This fixes the build failure in #122.

## Test plan

- [x] Tested locally - build succeeds with new content files
- [ ] Merge this PR, then re-run PR #122 checks