### PR TITLE
Remove stale pagination cursors causing 404s

### DIFF
--- a/pages/archive/[slug].js
+++ b/pages/archive/[slug].js
@@ -85,25 +85,11 @@ const EventPage = (props) => {
 export default EventPage
 
 export const getStaticPaths = async () => {
-	const countResult = await client.request({
-		query: `{ archiveConnection { totalCount } }`,
-	})
-	const totalCount = countResult.data.archiveConnection.totalCount
+	const length = await client.queries.archiveConnection()
+	const postCount = length.data.archiveConnection.totalCount
 
-	const {data} = await client.request({
-		query: `
-		query getPaths($count: Float) {
-			archiveConnection(last: $count, before: "cG9zdCNkYXRlIzE2NTc4Njg0MDAwMDAjY29udGVudC9wb3N0cy9hbm90aGVyUG9zdC5qc29u") {
-				edges {
-					node {
-						_sys {
-							filename
-						}
-					}
-				}
-			}
-		}`,
-		variables: {count: totalCount},
+	const {data} = await client.queries.archiveConnection({
+		last: postCount,
 	})
 
 	const paths = data.archiveConnection.edges.map((x) => {

--- a/pages/archive/events.js
+++ b/pages/archive/events.js
@@ -89,7 +89,7 @@ export const getStaticProps = async () => {
 	const {data} = await client.request({
 		query: `
       {
-      archiveConnection(filter: {categories: {category: {category: {title: {eq: "Event"}}}}}, sort: "published", last:30, before: "cG9zdCNkYXRlIzE2NTc4Njg0MDAwMDAjY29udGVudC9wb3N0cy9hbm90aGVyUG9zdC5qc29u") {
+      archiveConnection(filter: {categories: {category: {category: {title: {eq: "Event"}}}}}, sort: "published", last:30) {
       edges {
         node {
           id

--- a/pages/archive/index.js
+++ b/pages/archive/index.js
@@ -129,7 +129,7 @@ export const getStaticProps = async () => {
 		query: `
     query getContent($eventCount: Float, $endOfWeek: String)
     {
-      archiveConnection(filter: {published: {before: $endOfWeek}}, sort: "published", last: $eventCount, before: "cG9zdCNkYXRlIzE2NTc4Njg0MDAwMDAjY29udGVudC9wb3N0cy9hbm90aGVyUG9zdC5qc29u"){
+      archiveConnection(filter: {published: {before: $endOfWeek}}, sort: "published", last: $eventCount){
         edges {
           node {
             id

--- a/pages/archive/specialty-shows/[slug].js
+++ b/pages/archive/specialty-shows/[slug].js
@@ -136,7 +136,7 @@ export const getStaticProps = async (ctx) => {
 	const {data} = await client.request({
 		query: `
       query getContent($title: String, $endOfWeek: String) {
-      archiveConnection(filter: {categories: {category: {category: {title: {eq: $title}}}}, published: {before: $endOfWeek}}, sort: "published", last: 30, before: "cG9zdCNkYXRlIzE2NTc4Njg0MDAwMDAjY29udGVudC9wb3N0cy9hbm90aGVyUG9zdC5qc29u") {
+      archiveConnection(filter: {categories: {category: {category: {title: {eq: $title}}}}, published: {before: $endOfWeek}}, sort: "published", last: 100) {
       edges {
         node {
           id

--- a/pages/archive/specialty-shows/index.js
+++ b/pages/archive/specialty-shows/index.js
@@ -115,7 +115,7 @@ export const getStaticProps = async () => {
 		query: `
 		query getContent($endOfWeek:String, $eventCount: Float)  
 		{
-		  archiveConnection(filter: {categories: {category: {category: {title: {eq: "Specialty Show"}}}}, published: {before: $endOfWeek}}, sort: "published", last:$eventCount, before: "cG9zdCNkYXRlIzE2NTc4Njg0MDAwMDAjY29udGVudC9wb3N0cy9hbm90aGVyUG9zdC5qc29u") {
+		  archiveConnection(filter: {categories: {category: {category: {title: {eq: "Specialty Show"}}}}, published: {before: $endOfWeek}}, sort: "published", last:$eventCount) {
 		  edges {
 			node {
 			  id

--- a/pages/blog/category/[slug].js
+++ b/pages/blog/category/[slug].js
@@ -87,7 +87,7 @@ export const getStaticProps = async (ctx) => {
 	const {data} = await client.request({
 		query: `
         query getContent($title: String) {
-        blogConnection(filter: {categories: {category: {category: {title: {eq: $title}}}}}, sort: "published", last:30, before: "cG9zdCNkYXRlIzE2NTc4Njg0MDAwMDAjY29udGVudC9wb3N0cy9hbm90aGVyUG9zdC5qc29u") {
+        blogConnection(filter: {categories: {category: {category: {title: {eq: $title}}}}}, sort: "published", last:30) {
         edges {
           node {
             id

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -128,7 +128,7 @@ export const getStaticProps = async () => {
 		query: `
     query getContent($postCount: Float)
     {
-      blogConnection(sort: "published", last: $postCount, before: "cG9zdCNkYXRlIzE2NTc4Njg0MDAwMDAjY29udGVudC9wb3N0cy9hbm90aGVyUG9zdC5qc29u"){
+      blogConnection(sort: "published", last: $postCount){
         edges {
           node {
             id

--- a/pages/index.js
+++ b/pages/index.js
@@ -94,7 +94,7 @@ export const getStaticProps = async () => {
 		query: `
     query getContent($startOfWeek: String, $endOfWeek: String)
     {    
-        blogConnection(sort: "published", last:6, before: "cG9zdCNkYXRlIzE2NTc4Njg0MDAwMDAjY29udGVudC9wb3N0cy9hbm90aGVyUG9zdC5qc29u"){
+        blogConnection(sort: "published", last:6){
           edges {
             node {
               id
@@ -119,7 +119,7 @@ export const getStaticProps = async () => {
           }
         },
        
-      archiveConnection(filter: {published: {after: $startOfWeek, before: $endOfWeek}}, sort: "published", last:30, before: "cG9zdCNkYXRlIzE2NTc4Njg0MDAwMDAjY29udGVudC9wb3N0cy9hbm90aGVyUG9zdC5qc29u") {
+      archiveConnection(filter: {published: {after: $startOfWeek, before: $endOfWeek}}, sort: "published", last:30) {
         edges {
           node {
             id


### PR DESCRIPTION
## Summary

- Remove hardcoded TinaCMS Relay `before` cursor (pointing to July 2022) from all GraphQL queries across 8 files
- Replace raw GraphQL in archive `getStaticPaths` with the typed `client.queries.archiveConnection()` pattern
- Increase specialty show episode limit from 30 to 100

Closes #147

## Test plan

- [x] Verify `npm run build` succeeds (all archive/blog pages are generated)
- [ ] Verify https://wxyc.org/archive/karen-dalton-07-20-2025 loads after deploy
- [ ] Verify homepage blog carousel and archive carousel show recent content
- [ ] Verify /blog, /archive, /archive/events, /archive/specialty-shows list pages show recent content