### PR TITLE
ci: pin workflow-level GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -7,6 +7,12 @@ concurrency:
   group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
+# comments on PRs, or creates releases; all writes to external services
+# use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+permissions:
+  contents: read
+
 jobs:
   # Build job
   build:


### PR DESCRIPTION
Closes #171.

Adds a top-level `permissions:` block to every workflow so the GITHUB_TOKEN runs with a least-privilege scope pinned in code, instead of inheriting whatever the repo-wide default happens to be.

- `pr-open.yml`: contents: read

Behavior-neutral today (no job writes via GITHUB_TOKEN beyond what the block grants) but pins the safe posture so future jobs can't silently inherit write scopes.

Part of the org-wide GitHub Actions hardening project (Phase 3).