### PR TITLE
ci: bump Pages actions to Node 24 majors (deploy-pages, configure-pages)

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -101,4 +101,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -54,7 +54,7 @@ jobs:
           node-version: '24'
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           # Automatically inject basePath in your Next.js configuration file and disable
           # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -43,7 +43,7 @@ jobs:
           node-version: '24'
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           # Automatically inject basePath in your Next.js configuration file and disable
           # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).


### PR DESCRIPTION
## Summary

Bump the last two `node20` action pins in the website's workflows ahead of GitHub's 2026-06-02 internal-runtime hard-deprecation.

- `actions/deploy-pages@v4` → `@v5` in `.github/workflows/nextjs.yml:104`
- `actions/configure-pages@v5` → `@v6` in `.github/workflows/nextjs.yml:57` and `.github/workflows/pr-open.yml:46`

The configure-pages straggler surfaced in this PR's own first CI run: the green build's annotation log called out `actions/configure-pages@v5` as still on Node 20. Folded the bump in rather than splitting.

## Verification

| Action | Bumped to | `runs.using` at new ref | Changelog |
|---|---|---|---|
| `actions/deploy-pages` | `v5.0.0` | `node24` | "Update Node.js version to 24.x" — no input/behavior changes |
| `actions/configure-pages` | `v6.0.0` | `node24` | "upgrade to node 24" — no input/behavior changes |

`actions/upload-pages-artifact@v4` (the other Pages-adjacent pin) is a composite action with no internal Node runtime — survives the flip unchanged.

Closes #173.

## Test plan

- [ ] PR CI (`Test build (pr-open)`) runs green AND its annotation log no longer flags `actions/configure-pages` (this PR's second push validates this).
- [ ] After merge, the `nextjs.yml` `deploy` job completes green from the bumped `deploy-pages` pin.
- [ ] No `Node.js 20` deprecation warning lines in either run log.