### PR TITLE
ci: bump actions/upload-pages-artifact to v5 (transitive node20 → node24)

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -87,7 +87,7 @@ jobs:
           NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
 


### PR DESCRIPTION
## Summary

Bump `actions/upload-pages-artifact@v4` → `@v5` in `.github/workflows/nextjs.yml:90`. This is the third and final `node20`-dependent action pin in the website's workflows, surfaced as a transitive annotation in #174's post-merge deploy run.

## Verification

| Aspect | Detail |
|---|---|
| Current pin | `upload-pages-artifact@v4` (composite) → internally `upload-artifact@v4.6.2` (`node20`) |
| New pin | `upload-pages-artifact@v5.0.0` (composite) → internally `upload-artifact@v7.0.0` (`node24`) |
| Composite output contract | unchanged (`artifact_id`, `artifact_url`) |
| v5.0.0 changelog | internal artifact-action bump + additive `include-hidden-files` input |

The website only consumes `upload-pages-artifact`'s outputs (passed downstream to `deploy-pages` by name), so the `upload-artifact@v4 → @v7` internal jump is invisible at the workflow surface.

Closes #175.

## Test plan

- [ ] PR CI (`Test build (pr-open)`) runs green.
- [ ] After merge, the `nextjs.yml` `build` job's `Upload artifact` step completes and the `deploy` job pulls + deploys the artifact successfully.
- [ ] **No `Node.js 20` deprecation warning lines remain** in the post-merge deploy run log (the success criterion this PR is trying to satisfy).