### PR TITLE
restore: bring back wxyc-is-hiring-new-djs-spring-2026.md to unblock Pages deploy

### DIFF
--- a/content/blog/wxyc-is-hiring-new-djs-spring-2026.md
+++ b/content/blog/wxyc-is-hiring-new-djs-spring-2026.md
@@ -1,0 +1,24 @@
+---
+title: WXYC is Hiring New DJs Spring 2026!
+cover: /uploads/89.3.png
+categories:
+  - category: content/category/event.md
+published: 2025-12-20T05:00:00.000Z
+description: We're hiring! No experience is necessary!
+---
+
+Do you love music? Join UNC's student-run radio station, broadcasting live 24/7 from the student union.
+
+Since 1977, WXYC has served the communities of Chapel Hill, Carrboro, and beyond with our adventurous and exploratory programming. We're looking for new student DJs to join our community and host their own radio show. 
+
+Discover new music, serve the community, and contribute to a nearly 50-year legacy of independent music. Long live college radio! For any questions, please email [info@wxyc.org](mailto:info@wxyc.org) or DM @wxyc893 on Instagram.
+
+Interest meeting: Friday, January 9th, 4:30pm at the Wilson Library Steps
+
+Interviews: Tuesday, January 13th through Thursday, January 15th from 5-8pm.
+
+Sign up for an interview first and then fill out your application any time before your time slot. To give our team time to review your application, please submit it by 11:59pm the night before your interview. 
+
+[Interview signup link here!](https://www.signupgenius.com/go/60B084FAFAE2AA7FC1-61347436-wxyc)
+
+[Application link here!](https://docs.google.com/forms/d/e/1FAIpQLSciTNJzfKornXCM1gbUfX5001ZbFqFvXPPrkIrEdfmsFMoSww/viewform?usp=header)


### PR DESCRIPTION
## Summary

- Reverts a980469 (TinaCMS-bot delete of `wxyc-is-hiring-new-djs-spring-2026.md`) to unblock the Pages deploy.
- The delete left TinaCloud's GraphQL index in a stale state: the file is gone from the repo but `blogConnection` still returns an edge for it. Resolving that edge fails the `/blog` prerender, which fails the static export. All 4 Pages deploys triggered by Julian's content edits last night (delete + 2 image uploads + new Teens in Trouble post) failed on this same error.
- Re-running the latest workflow 14 hours later hit the same error, so TinaCloud is not self-healing on its own. Restoring the file makes the connection walk succeed so the queued content can ship. The hiring post can be deleted again via the Tina admin once the index is back in sync.

Failing run for reference: https://github.com/WXYC/website/actions/runs/27449471066

## Test plan

- [x] `npm ci` clean
- [x] `npm test` — 59 / 59 pass
- [x] `npm run lint` — no new warnings vs `main`
- [x] `npx tinacms dev` + `npx next build` (local-mode build, same as PR CI) — `/blog`, `/blog/[slug]` (68 paths), `/archive/[slug]` (138 paths) all prerender successfully
- [ ] Pages deploy on merge — confirms TinaCloud GraphQL resolves the restored edge