### PR TITLE
Stop one stale-published doc from freezing the whole Pages deploy

### DIFF
--- a/__tests__/resilientPosts.test.js
+++ b/__tests__/resilientPosts.test.js
@@ -3,28 +3,35 @@ import {
 	fetchCollectionNodes,
 	sortByPublishedDesc,
 	filterByPublishedWindow,
+	filterByCategoryTitle,
 } from '../lib/resilientPosts'
 
-// Build a `request` mock that returns one connection page. `byQuery` maps a
-// substring of the GraphQL query to the connection payload it should resolve
-// (or an Error to reject with), letting a test make the full-field walk fail
-// while the filename-only walk succeeds.
-function mockRequest(connection, byQuery) {
-	return vi.fn(({query}) => {
-		for (const [needle, payload] of byQuery) {
-			if (query.includes(needle)) {
-				if (payload instanceof Error) return Promise.reject(payload)
-				return Promise.resolve({data: {[connection]: payload}})
+// Build a mock Tina `client` whose `request` returns one connection page per
+// matching query. `byQuery` maps a substring of the GraphQL query to the
+// connection payload it should resolve (or an Error to reject with), letting a
+// test make the full-field walk fail while the filename-only walk succeeds.
+// `queries[collection]` is the per-document fallback fetch.
+function mockClient(connection, byQuery, queries = {}) {
+	return {
+		request: vi.fn(({query}) => {
+			for (const [needle, payload] of byQuery) {
+				if (query.includes(needle)) {
+					if (payload instanceof Error) return Promise.reject(payload)
+					return Promise.resolve({data: {[connection]: payload}})
+				}
 			}
-		}
-		throw new Error(`unexpected query: ${query}`)
-	})
+			throw new Error(`unexpected query: ${query}`)
+		}),
+		queries,
+	}
 }
 
 const page = (edges) => ({
 	edges,
 	pageInfo: {hasNextPage: false, endCursor: null},
 })
+
+const node = (filename, fields = {}) => ({node: {_sys: {filename}, ...fields}})
 
 describe('resilientPosts', () => {
 	beforeEach(() => {
@@ -55,6 +62,23 @@ describe('resilientPosts', () => {
 			expect(sortByPublishedDesc(nodes)[0].title).toBe('dated')
 		})
 
+		it('does not treat a valid pre-1970 date as missing', () => {
+			const nodes = [
+				{title: 'undated', _sys: {filename: 'z'}},
+				{title: 'epoch', published: '1969-01-01', _sys: {filename: 'a'}},
+			]
+			// The real (pre-epoch) date must outrank the genuinely-undated node.
+			expect(sortByPublishedDesc(nodes)[0].title).toBe('epoch')
+		})
+
+		it('breaks ties by filename for deterministic order', () => {
+			const nodes = [
+				{title: 'b', published: '2025-01-01', _sys: {filename: 'b-post'}},
+				{title: 'a', published: '2025-01-01', _sys: {filename: 'a-post'}},
+			]
+			expect(sortByPublishedDesc(nodes).map((n) => n.title)).toEqual(['a', 'b'])
+		})
+
 		it('does not mutate the input array', () => {
 			const nodes = [
 				{title: 'a', published: '2024-01-01'},
@@ -73,7 +97,7 @@ describe('resilientPosts', () => {
 			{title: 'undated'},
 		]
 
-		it('keeps only nodes inside the half-open window', () => {
+		it('keeps only nodes strictly inside the open window', () => {
 			const result = filterByPublishedWindow(nodes, {
 				after: '2026-06-05',
 				before: '2026-06-15',
@@ -81,11 +105,18 @@ describe('resilientPosts', () => {
 			expect(result.map((n) => n.title)).toEqual(['inside'])
 		})
 
-		it('treats the upper bound as exclusive', () => {
-			const result = filterByPublishedWindow(nodes, {
-				before: '2026-06-10',
-			})
-			expect(result.map((n) => n.title)).toEqual(['before'])
+		it('treats both bounds as exclusive, matching Tina', () => {
+			// 'inside' sits exactly on both bounds and must be excluded from each.
+			expect(
+				filterByPublishedWindow(nodes, {after: '2026-06-10'}).map(
+					(n) => n.title
+				)
+			).toEqual(['after'])
+			expect(
+				filterByPublishedWindow(nodes, {before: '2026-06-10'}).map(
+					(n) => n.title
+				)
+			).toEqual(['before'])
 		})
 
 		it('drops nodes with missing published dates', () => {
@@ -94,64 +125,120 @@ describe('resilientPosts', () => {
 		})
 	})
 
+	describe('filterByCategoryTitle', () => {
+		const cat = (title) => ({categories: [{category: {title}}]})
+
+		it('keeps nodes referencing the given category title', () => {
+			const nodes = [
+				{title: 'a', ...cat('Event')},
+				{title: 'b', ...cat('Specialty Show')},
+				{title: 'c', ...cat('Event')},
+			]
+			expect(filterByCategoryTitle(nodes, 'Event').map((n) => n.title)).toEqual(
+				['a', 'c']
+			)
+		})
+
+		it('tolerates nodes with no categories array', () => {
+			const nodes = [{title: 'a'}, {title: 'b', ...cat('Event')}]
+			expect(filterByCategoryTitle(nodes, 'Event').map((n) => n.title)).toEqual(
+				['b']
+			)
+		})
+	})
+
 	describe('fetchCollectionNodes', () => {
 		const fields = 'id title cover published _sys { filename }'
 
 		it('returns nodes from the unsorted walk on the happy path', async () => {
-			const request = mockRequest('blogConnection', [
+			const queries = {blog: vi.fn()}
+			const client = mockClient(
+				'blogConnection',
 				[
-					'title',
-					page([
-						{node: {title: 'a', published: '2025-01-01'}},
-						{node: {title: 'b', published: '2026-01-01'}},
-					]),
+					[
+						'title',
+						page([
+							{node: {title: 'a', published: '2025-01-01'}},
+							{node: {title: 'b', published: '2026-01-01'}},
+						]),
+					],
 				],
-			])
-			const fetchOne = vi.fn()
+				queries
+			)
 
 			const nodes = await fetchCollectionNodes({
-				connection: 'blogConnection',
+				client,
+				collection: 'blog',
 				fields,
-				request,
-				fetchOne,
 				label: 'blog',
 			})
 
 			expect(nodes.map((n) => n.title)).toEqual(['a', 'b'])
 			// Happy path must never touch the per-document fallback.
-			expect(fetchOne).not.toHaveBeenCalled()
+			expect(queries.blog).not.toHaveBeenCalled()
 		})
 
 		it('falls back to per-document fetch when the full walk fails', async () => {
-			const request = mockRequest('blogConnection', [
-				// The full-field walk (selecting `title`) fails like a broken index...
-				['title', new Error('Error querying file bad.md from collection blog')],
-				// ...but the filename-only walk still resolves.
+			const queries = {
+				blog: vi.fn((args) =>
+					args.relativePath === 'bad.md'
+						? Promise.reject(new Error('still broken'))
+						: Promise.resolve({
+								data: {blog: {title: args.relativePath, _sys: args}},
+							})
+				),
+			}
+			const client = mockClient(
+				'blogConnection',
 				[
-					'_sys { filename }',
-					page([
-						{node: {_sys: {filename: 'good'}}},
-						{node: {_sys: {filename: 'bad'}}},
-					]),
+					// The full-field walk (selecting `title`) fails like a broken index...
+					[
+						'title',
+						new Error('Error querying file bad.md from collection blog'),
+					],
+					// ...but the filename-only walk still resolves.
+					['_sys { filename }', page([node('good'), node('bad')])],
 				],
-			])
-			const fetchOne = vi.fn((filename) =>
-				filename === 'bad'
-					? Promise.reject(new Error('still broken'))
-					: Promise.resolve({title: filename, _sys: {filename}})
+				queries
 			)
 
 			const nodes = await fetchCollectionNodes({
-				connection: 'blogConnection',
+				client,
+				collection: 'blog',
 				fields,
-				request,
-				fetchOne,
 				label: 'blog',
 			})
 
 			// The good document survives; the broken one is skipped, not fatal.
-			expect(nodes.map((n) => n.title)).toEqual(['good'])
-			expect(fetchOne).toHaveBeenCalledTimes(2)
+			expect(nodes.map((n) => n.title)).toEqual(['good.md'])
+			expect(queries.blog).toHaveBeenCalledTimes(2)
+		})
+
+		it('skips fallback edges that have no filename without calling fetch', async () => {
+			const queries = {
+				blog: vi.fn((args) =>
+					Promise.resolve({data: {blog: {title: args.relativePath}}})
+				),
+			}
+			const client = mockClient(
+				'blogConnection',
+				[
+					['title', new Error('broken index')],
+					['_sys { filename }', page([{node: {_sys: {}}}, node('ok')])],
+				],
+				queries
+			)
+
+			const nodes = await fetchCollectionNodes({
+				client,
+				collection: 'blog',
+				fields,
+				label: 'blog',
+			})
+
+			expect(nodes.map((n) => n.title)).toEqual(['ok.md'])
+			// The filename-less edge must not trigger a `client.queries.blog(undefined)` call.
+			expect(queries.blog).toHaveBeenCalledTimes(1)
 		})
 	})
 })

--- a/__tests__/resilientPosts.test.js
+++ b/__tests__/resilientPosts.test.js
@@ -266,5 +266,35 @@ describe('resilientPosts', () => {
 			expect(nodes).toEqual([])
 			expect(queries.blog).not.toHaveBeenCalled()
 		})
+
+		it('recovers via the filename walk when only the full-field walk returns null', async () => {
+			// A null on the full-field walk must be treated as a failure and fall
+			// back to the (here-succeeding) filename walk, not silently truncate.
+			const queries = {
+				blog: vi.fn((args) =>
+					Promise.resolve({data: {blog: {title: args.relativePath}}})
+				),
+			}
+			const client = mockClient(
+				'blogConnection',
+				[
+					// Full-field walk (contains `title`) returns a null connection...
+					['title', null],
+					// ...but the filename-only walk resolves with real edges.
+					['_sys { filename }', page([node('a'), node('b')])],
+				],
+				queries
+			)
+
+			const nodes = await fetchCollectionNodes({
+				client,
+				collection: 'blog',
+				fields,
+				label: 'blog',
+			})
+
+			expect(nodes.map((n) => n.title)).toEqual(['a.md', 'b.md'])
+			expect(queries.blog).toHaveBeenCalledTimes(2)
+		})
 	})
 })

--- a/__tests__/resilientPosts.test.js
+++ b/__tests__/resilientPosts.test.js
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi, beforeEach} from 'vitest'
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest'
 import {
 	fetchCollectionNodes,
 	sortByPublishedDesc,
@@ -37,6 +37,11 @@ describe('resilientPosts', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		vi.spyOn(console, 'warn').mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		// Restore the console.warn spy so it can't leak into sibling test files.
+		vi.restoreAllMocks()
 	})
 
 	describe('sortByPublishedDesc', () => {
@@ -239,6 +244,27 @@ describe('resilientPosts', () => {
 			expect(nodes.map((n) => n.title)).toEqual(['ok.md'])
 			// The filename-less edge must not trigger a `client.queries.blog(undefined)` call.
 			expect(queries.blog).toHaveBeenCalledTimes(1)
+		})
+
+		it('returns an empty list without crashing when the connection resolves to null', async () => {
+			// A broken index can return `{data: {blogConnection: null}}` (a resolved
+			// 200, not a rejection); this must not throw and break the build.
+			const queries = {blog: vi.fn()}
+			const client = mockClient(
+				'blogConnection',
+				[['blogConnection', null]],
+				queries
+			)
+
+			const nodes = await fetchCollectionNodes({
+				client,
+				collection: 'blog',
+				fields,
+				label: 'blog',
+			})
+
+			expect(nodes).toEqual([])
+			expect(queries.blog).not.toHaveBeenCalled()
 		})
 	})
 })

--- a/__tests__/resilientPosts.test.js
+++ b/__tests__/resilientPosts.test.js
@@ -1,0 +1,157 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest'
+import {
+	fetchCollectionNodes,
+	sortByPublishedDesc,
+	filterByPublishedWindow,
+} from '../lib/resilientPosts'
+
+// Build a `request` mock that returns one connection page. `byQuery` maps a
+// substring of the GraphQL query to the connection payload it should resolve
+// (or an Error to reject with), letting a test make the full-field walk fail
+// while the filename-only walk succeeds.
+function mockRequest(connection, byQuery) {
+	return vi.fn(({query}) => {
+		for (const [needle, payload] of byQuery) {
+			if (query.includes(needle)) {
+				if (payload instanceof Error) return Promise.reject(payload)
+				return Promise.resolve({data: {[connection]: payload}})
+			}
+		}
+		throw new Error(`unexpected query: ${query}`)
+	})
+}
+
+const page = (edges) => ({
+	edges,
+	pageInfo: {hasNextPage: false, endCursor: null},
+})
+
+describe('resilientPosts', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.spyOn(console, 'warn').mockImplementation(() => {})
+	})
+
+	describe('sortByPublishedDesc', () => {
+		it('orders newest first', () => {
+			const nodes = [
+				{title: 'old', published: '2024-01-01'},
+				{title: 'new', published: '2026-06-01'},
+				{title: 'mid', published: '2025-03-15'},
+			]
+			expect(sortByPublishedDesc(nodes).map((n) => n.title)).toEqual([
+				'new',
+				'mid',
+				'old',
+			])
+		})
+
+		it('sorts nodes with missing or invalid published dates last', () => {
+			const nodes = [
+				{title: 'missing'},
+				{title: 'dated', published: '2025-01-01'},
+				{title: 'garbage', published: 'not-a-date'},
+			]
+			expect(sortByPublishedDesc(nodes)[0].title).toBe('dated')
+		})
+
+		it('does not mutate the input array', () => {
+			const nodes = [
+				{title: 'a', published: '2024-01-01'},
+				{title: 'b', published: '2026-01-01'},
+			]
+			sortByPublishedDesc(nodes)
+			expect(nodes.map((n) => n.title)).toEqual(['a', 'b'])
+		})
+	})
+
+	describe('filterByPublishedWindow', () => {
+		const nodes = [
+			{title: 'before', published: '2026-06-01'},
+			{title: 'inside', published: '2026-06-10'},
+			{title: 'after', published: '2026-06-20'},
+			{title: 'undated'},
+		]
+
+		it('keeps only nodes inside the half-open window', () => {
+			const result = filterByPublishedWindow(nodes, {
+				after: '2026-06-05',
+				before: '2026-06-15',
+			})
+			expect(result.map((n) => n.title)).toEqual(['inside'])
+		})
+
+		it('treats the upper bound as exclusive', () => {
+			const result = filterByPublishedWindow(nodes, {
+				before: '2026-06-10',
+			})
+			expect(result.map((n) => n.title)).toEqual(['before'])
+		})
+
+		it('drops nodes with missing published dates', () => {
+			const result = filterByPublishedWindow(nodes, {})
+			expect(result.map((n) => n.title)).not.toContain('undated')
+		})
+	})
+
+	describe('fetchCollectionNodes', () => {
+		const fields = 'id title cover published _sys { filename }'
+
+		it('returns nodes from the unsorted walk on the happy path', async () => {
+			const request = mockRequest('blogConnection', [
+				[
+					'title',
+					page([
+						{node: {title: 'a', published: '2025-01-01'}},
+						{node: {title: 'b', published: '2026-01-01'}},
+					]),
+				],
+			])
+			const fetchOne = vi.fn()
+
+			const nodes = await fetchCollectionNodes({
+				connection: 'blogConnection',
+				fields,
+				request,
+				fetchOne,
+				label: 'blog',
+			})
+
+			expect(nodes.map((n) => n.title)).toEqual(['a', 'b'])
+			// Happy path must never touch the per-document fallback.
+			expect(fetchOne).not.toHaveBeenCalled()
+		})
+
+		it('falls back to per-document fetch when the full walk fails', async () => {
+			const request = mockRequest('blogConnection', [
+				// The full-field walk (selecting `title`) fails like a broken index...
+				['title', new Error('Error querying file bad.md from collection blog')],
+				// ...but the filename-only walk still resolves.
+				[
+					'_sys { filename }',
+					page([
+						{node: {_sys: {filename: 'good'}}},
+						{node: {_sys: {filename: 'bad'}}},
+					]),
+				],
+			])
+			const fetchOne = vi.fn((filename) =>
+				filename === 'bad'
+					? Promise.reject(new Error('still broken'))
+					: Promise.resolve({title: filename, _sys: {filename}})
+			)
+
+			const nodes = await fetchCollectionNodes({
+				connection: 'blogConnection',
+				fields,
+				request,
+				fetchOne,
+				label: 'blog',
+			})
+
+			// The good document survives; the broken one is skipped, not fatal.
+			expect(nodes.map((n) => n.title)).toEqual(['good'])
+			expect(fetchOne).toHaveBeenCalledTimes(2)
+		})
+	})
+})

--- a/lib/resilientPosts.js
+++ b/lib/resilientPosts.js
@@ -1,0 +1,115 @@
+import {fetchAllEdges} from './tinaPagination'
+
+/**
+ * Fetch every node from a Tina collection WITHOUT relying on Tina Cloud's
+ * server-side `sort: "published"` or `filter: {published: ...}`.
+ *
+ * Why this exists: a single document whose indexed `published` value is missing
+ * or stale makes those server-side operations throw
+ * `Error querying file <name> from collection <collection>`, which fails the
+ * entire `next build` static export and freezes the GitHub Pages deploy.
+ * Editors trip this routinely by creating, deleting, or re-saving posts, so the
+ * whole site stops updating until someone re-indexes the content. We instead
+ * pull documents with index-tolerant queries and do all ordering/windowing in
+ * JS (see `sortByPublishedDesc` / `filterByPublishedWindow`), so one bad post
+ * can demote or drop itself but can never break the build.
+ *
+ * Happy path: walk the collection unsorted, requesting the display `fields`.
+ * Fallback (only if that walk throws): walk unsorted requesting just the
+ * filename — the one query shape proven to resolve against a broken index, the
+ * same one the per-post pages use — then fetch each document individually via
+ * `fetchOne`, skipping (and logging) any that still fail.
+ *
+ * @param {Object} opts
+ * @param {string} opts.connection  Tina connection field, e.g. 'blogConnection'
+ * @param {string} opts.fields      node sub-selection, e.g. 'id title cover ...'
+ * @param {(q: {query: string, variables: object}) => Promise<{data: object}>} opts.request
+ *        issues one GraphQL request (pages pass `(q) => client.request(q)`)
+ * @param {(filename: string) => Promise<object>} opts.fetchOne
+ *        fetches a single document by filename (pages pass a `client.queries.*` call)
+ * @param {string} opts.label       label used in build-log warnings
+ * @returns {Promise<object[]>} array of node objects (unsorted)
+ */
+export async function fetchCollectionNodes({
+	connection,
+	fields,
+	request,
+	fetchOne,
+	label,
+}) {
+	const walk = (selection) => (after) =>
+		request({
+			query: `
+				query ResilientWalk($first: Float, $after: String) {
+					${connection}(first: $first, after: $after) {
+						edges { node { ${selection} } }
+						pageInfo { hasNextPage endCursor }
+					}
+				}
+			`,
+			variables: {first: 50, after},
+		}).then(({data}) => data[connection])
+
+	try {
+		const edges = await fetchAllEdges(walk(fields))
+		return edges.map((edge) => edge.node)
+	} catch (err) {
+		console.warn(
+			`[${label}] full connection walk failed (${err.message}); ` +
+				'falling back to per-document fetch'
+		)
+	}
+
+	const fileEdges = await fetchAllEdges(walk('_sys { filename }'))
+	const nodes = []
+	const skipped = []
+	for (const {node} of fileEdges) {
+		const filename = node?._sys?.filename
+		try {
+			nodes.push(await fetchOne(filename))
+		} catch (err) {
+			skipped.push(filename)
+			console.warn(`[${label}] skipping "${filename}": ${err.message}`)
+		}
+	}
+	if (skipped.length) {
+		console.warn(
+			`[${label}] ${skipped.length} document(s) skipped: ${skipped.join(', ')}`
+		)
+	}
+	return nodes
+}
+
+/**
+ * Milliseconds since epoch for a node's `published` date, or 0 when it is
+ * missing or unparseable (so such nodes sort last and fall outside any window).
+ */
+function publishedTime(node) {
+	const time = Date.parse(node?.published)
+	return Number.isNaN(time) ? 0 : time
+}
+
+/**
+ * Return a new array of nodes ordered newest-first by `published`. Nodes with a
+ * missing or invalid `published` sort to the end. Does not mutate the input.
+ */
+export function sortByPublishedDesc(nodes) {
+	return [...nodes].sort((a, b) => publishedTime(b) - publishedTime(a))
+}
+
+/**
+ * Keep nodes whose `published` falls in the half-open window `[after, before)`.
+ * Either bound may be omitted (treated as unbounded). Nodes with a missing or
+ * invalid `published` are dropped.
+ *
+ * @param {object[]} nodes
+ * @param {{after?: Date|string|number, before?: Date|string|number}} [window]
+ */
+export function filterByPublishedWindow(nodes, {after, before} = {}) {
+	const lo = after == null ? -Infinity : new Date(after).getTime()
+	const hi = before == null ? Infinity : new Date(before).getTime()
+	return nodes.filter((node) => {
+		const time = publishedTime(node)
+		return time > 0 && time >= lo && time < hi
+	})
+}

--- a/lib/resilientPosts.js
+++ b/lib/resilientPosts.js
@@ -1,4 +1,4 @@
-import {fetchAllEdges} from './tinaPagination'
+import {fetchAllEdges, TINA_PAGE_SIZE} from './tinaPagination'
 
 /**
  * Fetch every node from a Tina collection WITHOUT relying on Tina Cloud's
@@ -17,38 +17,38 @@ import {fetchAllEdges} from './tinaPagination'
  * Happy path: walk the collection unsorted, requesting the display `fields`.
  * Fallback (only if that walk throws): walk unsorted requesting just the
  * filename — the one query shape proven to resolve against a broken index, the
- * same one the per-post pages use — then fetch each document individually via
- * `fetchOne`, skipping (and logging) any that still fail.
+ * same one the per-post pages use — then fetch each document individually,
+ * skipping (and logging) any that still fail.
  *
  * @param {Object} opts
- * @param {string} opts.connection  Tina connection field, e.g. 'blogConnection'
+ * @param {object} opts.client      the generated Tina client (`tina/__generated__/client`)
+ * @param {string} opts.collection  collection name, e.g. 'blog' or 'archive'
  * @param {string} opts.fields      node sub-selection, e.g. 'id title cover ...'
- * @param {(q: {query: string, variables: object}) => Promise<{data: object}>} opts.request
- *        issues one GraphQL request (pages pass `(q) => client.request(q)`)
- * @param {(filename: string) => Promise<object>} opts.fetchOne
- *        fetches a single document by filename (pages pass a `client.queries.*` call)
  * @param {string} opts.label       label used in build-log warnings
  * @returns {Promise<object[]>} array of node objects (unsorted)
  */
 export async function fetchCollectionNodes({
-	connection,
+	client,
+	collection,
 	fields,
-	request,
-	fetchOne,
 	label,
 }) {
+	const connection = `${collection}Connection`
+
 	const walk = (selection) => (after) =>
-		request({
-			query: `
-				query ResilientWalk($first: Float, $after: String) {
-					${connection}(first: $first, after: $after) {
-						edges { node { ${selection} } }
-						pageInfo { hasNextPage endCursor }
+		client
+			.request({
+				query: `
+					query ResilientWalk($first: Float, $after: String) {
+						${connection}(first: $first, after: $after) {
+							edges { node { ${selection} } }
+							pageInfo { hasNextPage endCursor }
+						}
 					}
-				}
-			`,
-			variables: {first: 50, after},
-		}).then(({data}) => data[connection])
+				`,
+				variables: {first: TINA_PAGE_SIZE, after},
+			})
+			.then(({data}) => data[connection])
 
 	try {
 		const edges = await fetchAllEdges(walk(fields))
@@ -65,8 +65,15 @@ export async function fetchCollectionNodes({
 	const skipped = []
 	for (const {node} of fileEdges) {
 		const filename = node?._sys?.filename
+		if (!filename) {
+			console.warn(`[${label}] skipping an edge with no _sys.filename`)
+			continue
+		}
 		try {
-			nodes.push(await fetchOne(filename))
+			const res = await client.queries[collection]({
+				relativePath: `${filename}.md`,
+			})
+			nodes.push(res.data[collection])
 		} catch (err) {
 			skipped.push(filename)
 			console.warn(`[${label}] skipping "${filename}": ${err.message}`)
@@ -81,26 +88,44 @@ export async function fetchCollectionNodes({
 }
 
 /**
- * Milliseconds since epoch for a node's `published` date, or 0 when it is
- * missing or unparseable (so such nodes sort last and fall outside any window).
+ * Milliseconds since epoch for a node's `published` date, or `NaN` when it is
+ * missing or unparseable. `NaN` (not 0) is the sentinel so that a genuinely
+ * valid date — including the Unix epoch or any pre-1970 date — is never
+ * confused with "no date".
  */
 function publishedTime(node) {
-	const time = Date.parse(node?.published)
-	return Number.isNaN(time) ? 0 : time
+	return Date.parse(node?.published)
+}
+
+/** Ascending filename comparison, used as a stable tiebreak. */
+function byFilename(a, b) {
+	const fa = a?._sys?.filename ?? ''
+	const fb = b?._sys?.filename ?? ''
+	return fa < fb ? -1 : fa > fb ? 1 : 0
 }
 
 /**
- * Return a new array of nodes ordered newest-first by `published`. Nodes with a
+ * Return a new array of nodes ordered newest-first by `published`, breaking
+ * ties by filename so the order is deterministic across builds. Nodes with a
  * missing or invalid `published` sort to the end. Does not mutate the input.
  */
 export function sortByPublishedDesc(nodes) {
-	return [...nodes].sort((a, b) => publishedTime(b) - publishedTime(a))
+	return [...nodes].sort((a, b) => {
+		const ta = publishedTime(a)
+		const tb = publishedTime(b)
+		if (Number.isNaN(ta) && Number.isNaN(tb)) return byFilename(a, b)
+		if (Number.isNaN(ta)) return 1
+		if (Number.isNaN(tb)) return -1
+		if (tb !== ta) return tb - ta
+		return byFilename(a, b)
+	})
 }
 
 /**
- * Keep nodes whose `published` falls in the half-open window `[after, before)`.
- * Either bound may be omitted (treated as unbounded). Nodes with a missing or
- * invalid `published` are dropped.
+ * Keep nodes whose `published` falls in the window `(after, before)`. Both
+ * bounds are exclusive, matching Tina's datetime filter (`after` => `gt`,
+ * `before` => `lt`); either may be omitted (treated as unbounded). Nodes with a
+ * missing or invalid `published` are dropped.
  *
  * @param {object[]} nodes
  * @param {{after?: Date|string|number, before?: Date|string|number}} [window]
@@ -110,6 +135,17 @@ export function filterByPublishedWindow(nodes, {after, before} = {}) {
 	const hi = before == null ? Infinity : new Date(before).getTime()
 	return nodes.filter((node) => {
 		const time = publishedTime(node)
-		return time > 0 && time >= lo && time < hi
+		return !Number.isNaN(time) && time > lo && time < hi
 	})
+}
+
+/**
+ * Keep nodes that reference a category whose title exactly matches `title`.
+ * Tolerates the nested, polymorphic TinaCMS category reference shape
+ * (`node.categories[].category.title`) and a missing `categories` array.
+ */
+export function filterByCategoryTitle(nodes, title) {
+	return nodes.filter((node) =>
+		node.categories?.some((entry) => entry?.category?.title === title)
+	)
 }

--- a/lib/resilientPosts.js
+++ b/lib/resilientPosts.js
@@ -51,15 +51,12 @@ export async function fetchCollectionNodes({
 			.then(({data}) => {
 				// A broken index can return a 200 with `{data: {<connection>: null},
 				// errors: [...]}`, which the Tina client resolves rather than rejects.
-				// Treat a null connection as an empty page so neither the happy-path
-				// walk nor the fallback walk dereferences null and crashes the build.
+				// Throw so this is treated as a failure (triggering the fallback /
+				// degrading to an empty listing below) rather than an empty page —
+				// returning an empty page here would let a null on page 2+ silently
+				// truncate a multi-page walk to whatever was gathered so far.
 				const conn = data?.[connection]
-				if (!conn) {
-					console.warn(
-						`[${label}] "${connection}" returned no data; treating as empty`
-					)
-					return {edges: [], pageInfo: {hasNextPage: false, endCursor: null}}
-				}
+				if (!conn) throw new Error(`"${connection}" returned no data`)
 				return conn
 			})
 
@@ -73,7 +70,18 @@ export async function fetchCollectionNodes({
 		)
 	}
 
-	const fileEdges = await fetchAllEdges(walk('_sys { filename }'))
+	let fileEdges
+	try {
+		fileEdges = await fetchAllEdges(walk('_sys { filename }'))
+	} catch (err) {
+		// Even the lightweight filename-only walk failed (e.g. a persistently
+		// null connection). Degrade to an empty listing rather than crashing the
+		// whole static export — that is the entire point of this module.
+		console.warn(
+			`[${label}] filename walk also failed (${err.message}); returning no documents`
+		)
+		return []
+	}
 	const nodes = []
 	const skipped = []
 	for (const {node} of fileEdges) {

--- a/lib/resilientPosts.js
+++ b/lib/resilientPosts.js
@@ -48,7 +48,20 @@ export async function fetchCollectionNodes({
 				`,
 				variables: {first: TINA_PAGE_SIZE, after},
 			})
-			.then(({data}) => data[connection])
+			.then(({data}) => {
+				// A broken index can return a 200 with `{data: {<connection>: null},
+				// errors: [...]}`, which the Tina client resolves rather than rejects.
+				// Treat a null connection as an empty page so neither the happy-path
+				// walk nor the fallback walk dereferences null and crashes the build.
+				const conn = data?.[connection]
+				if (!conn) {
+					console.warn(
+						`[${label}] "${connection}" returned no data; treating as empty`
+					)
+					return {edges: [], pageInfo: {hasNextPage: false, endCursor: null}}
+				}
+				return conn
+			})
 
 	try {
 		const edges = await fetchAllEdges(walk(fields))

--- a/pages/archive/events.js
+++ b/pages/archive/events.js
@@ -10,6 +10,7 @@ import SeeMoreButton from '../../components/SeeMoreButton'
 import {
 	fetchCollectionNodes,
 	sortByPublishedDesc,
+	filterByCategoryTitle,
 } from '../../lib/resilientPosts'
 
 // page for filtering archive by event status (i.e. non-specialty shows)
@@ -97,7 +98,8 @@ export const getStaticProps = async () => {
 	// keep only "Event"-category items and order them newest-first in JS.
 	// See lib/resilientPosts.js.
 	const archiveNodes = await fetchCollectionNodes({
-		connection: 'archiveConnection',
+		client,
+		collection: 'archive',
 		fields: `
 			id
 			title
@@ -113,16 +115,9 @@ export const getStaticProps = async () => {
 			}
 			_sys { filename }
 		`,
-		request: (query) => client.request(query),
-		fetchOne: (filename) =>
-			client.queries
-				.archive({relativePath: `${filename}.md`})
-				.then((res) => res.data.archive),
 		label: 'archive/events',
 	})
-	const events = archiveNodes.filter((node) =>
-		node.categories?.some((entry) => entry?.category?.title === 'Event')
-	)
+	const events = filterByCategoryTitle(archiveNodes, 'Event')
 	const archiveEdges = sortByPublishedDesc(events).map((node) => ({node}))
 
 	const {data: categoryData} = await client.request({

--- a/pages/archive/events.js
+++ b/pages/archive/events.js
@@ -7,7 +7,10 @@ import {
 import ArchiveLayout from '../../components/ArchiveLayout'
 import React, {useState} from 'react'
 import SeeMoreButton from '../../components/SeeMoreButton'
-import {fetchAllEdges, TINA_PAGE_SIZE} from '../../lib/tinaPagination'
+import {
+	fetchCollectionNodes,
+	sortByPublishedDesc,
+} from '../../lib/resilientPosts'
 
 // page for filtering archive by event status (i.e. non-specialty shows)
 const EventsCategoryPage = (props) => {
@@ -89,35 +92,38 @@ const EventsCategoryPage = (props) => {
 export default EventsCategoryPage
 
 export const getStaticProps = async () => {
-	const archiveEdges = await fetchAllEdges(async (after) => {
-		const {data} = await client.request({
-			query: `
-				query GetEventArchive($first: Float, $after: String) {
-					archiveConnection(
-						filter: {categories: {category: {category: {title: {eq: "Event"}}}}}
-						sort: "published"
-						first: $first
-						after: $after
-					) {
-						edges {
-							node {
-								id
-								title
-								description
-								cover
-								published
-								_sys { filename }
-							}
-						}
-						pageInfo { hasNextPage endCursor }
+	// Pull every event without server-side `sort`/`filter` on `published` (which
+	// fails the whole export if any document has a stale `published` index), then
+	// keep only "Event"-category items and order them newest-first in JS.
+	// See lib/resilientPosts.js.
+	const archiveNodes = await fetchCollectionNodes({
+		connection: 'archiveConnection',
+		fields: `
+			id
+			title
+			description
+			cover
+			published
+			categories {
+				category {
+					... on Category {
+						title
 					}
 				}
-			`,
-			variables: {first: TINA_PAGE_SIZE, after},
-		})
-		return data.archiveConnection
+			}
+			_sys { filename }
+		`,
+		request: (query) => client.request(query),
+		fetchOne: (filename) =>
+			client.queries
+				.archive({relativePath: `${filename}.md`})
+				.then((res) => res.data.archive),
+		label: 'archive/events',
 	})
-	archiveEdges.reverse()
+	const events = archiveNodes.filter((node) =>
+		node.categories?.some((entry) => entry?.category?.title === 'Event')
+	)
+	const archiveEdges = sortByPublishedDesc(events).map((node) => ({node}))
 
 	const {data: categoryData} = await client.request({
 		query: `{

--- a/pages/archive/index.js
+++ b/pages/archive/index.js
@@ -12,7 +12,11 @@ import mobilephoto from '/images/crowdmobile.jpeg'
 import Image from 'next/image'
 import React, {useState} from 'react'
 import SeeMoreButton from '../../components/SeeMoreButton'
-import {fetchAllEdges, TINA_PAGE_SIZE} from '../../lib/tinaPagination'
+import {
+	fetchCollectionNodes,
+	sortByPublishedDesc,
+	filterByPublishedWindow,
+} from '../../lib/resilientPosts'
 
 // Helper to safely extract description text from TinaCMS rich-text field
 const getDescriptionText = (description, maxLength = 75) => {
@@ -116,37 +120,29 @@ export const getStaticProps = async () => {
 		currentDateTime.getMonth(),
 		currentDateTime.getDate() + (6 - currentDateTime.getDay())
 	)
-	const endOfWeekStr = endOfWeek.toDateString()
-
-	const archiveEdges = await fetchAllEdges(async (after) => {
-		const {data} = await client.request({
-			query: `
-				query GetEvents($first: Float, $after: String, $endOfWeek: String) {
-					archiveConnection(
-						filter: {published: {before: $endOfWeek}}
-						sort: "published"
-						first: $first
-						after: $after
-					) {
-						edges {
-							node {
-								id
-								title
-								cover
-								published
-								description
-								_sys { filename }
-							}
-						}
-						pageInfo { hasNextPage endCursor }
-					}
-				}
-			`,
-			variables: {first: TINA_PAGE_SIZE, after, endOfWeek: endOfWeekStr},
-		})
-		return data.archiveConnection
+	// Pull every event without server-side `sort`/`filter` on `published` (which
+	// fails the whole export if any document has a stale `published` index), then
+	// drop future events and order newest-first in JS. See lib/resilientPosts.js.
+	const archiveNodes = await fetchCollectionNodes({
+		connection: 'archiveConnection',
+		fields: `
+			id
+			title
+			cover
+			published
+			description
+			_sys { filename }
+		`,
+		request: (query) => client.request(query),
+		fetchOne: (filename) =>
+			client.queries
+				.archive({relativePath: `${filename}.md`})
+				.then((res) => res.data.archive),
+		label: 'archive/index',
 	})
-	archiveEdges.reverse()
+	const archiveEdges = sortByPublishedDesc(
+		filterByPublishedWindow(archiveNodes, {before: endOfWeek})
+	).map((node) => ({node}))
 
 	const {data: categoryData} = await client.request({
 		query: `{

--- a/pages/archive/index.js
+++ b/pages/archive/index.js
@@ -124,7 +124,8 @@ export const getStaticProps = async () => {
 	// fails the whole export if any document has a stale `published` index), then
 	// drop future events and order newest-first in JS. See lib/resilientPosts.js.
 	const archiveNodes = await fetchCollectionNodes({
-		connection: 'archiveConnection',
+		client,
+		collection: 'archive',
 		fields: `
 			id
 			title
@@ -133,11 +134,6 @@ export const getStaticProps = async () => {
 			description
 			_sys { filename }
 		`,
-		request: (query) => client.request(query),
-		fetchOne: (filename) =>
-			client.queries
-				.archive({relativePath: `${filename}.md`})
-				.then((res) => res.data.archive),
 		label: 'archive/index',
 	})
 	const archiveEdges = sortByPublishedDesc(

--- a/pages/archive/specialty-shows/[slug].js
+++ b/pages/archive/specialty-shows/[slug].js
@@ -12,6 +12,7 @@ import {
 	fetchCollectionNodes,
 	sortByPublishedDesc,
 	filterByPublishedWindow,
+	filterByCategoryTitle,
 } from '../../../lib/resilientPosts'
 
 // Helper to safely extract description text from TinaCMS rich-text field
@@ -147,7 +148,8 @@ export const getStaticProps = async (ctx) => {
 	// keep only this show's already-aired events and order them newest-first in
 	// JS. See lib/resilientPosts.js.
 	const archiveNodes = await fetchCollectionNodes({
-		connection: 'archiveConnection',
+		client,
+		collection: 'archive',
 		fields: `
 			id
 			title
@@ -163,17 +165,11 @@ export const getStaticProps = async (ctx) => {
 			}
 			_sys { filename }
 		`,
-		request: (query) => client.request(query),
-		fetchOne: (filename) =>
-			client.queries
-				.archive({relativePath: `${filename}.md`})
-				.then((res) => res.data.archive),
 		label: `archive/specialty-shows/${ctx.params.slug}`,
 	})
-	const showEvents = filterByPublishedWindow(archiveNodes, {
-		before: endOfWeek,
-	}).filter((node) =>
-		node.categories?.some((entry) => entry?.category?.title === categoryTitle)
+	const showEvents = filterByCategoryTitle(
+		filterByPublishedWindow(archiveNodes, {before: endOfWeek}),
+		categoryTitle
 	)
 	const archiveEdges = sortByPublishedDesc(showEvents).map((node) => ({node}))
 

--- a/pages/archive/specialty-shows/[slug].js
+++ b/pages/archive/specialty-shows/[slug].js
@@ -8,7 +8,11 @@ import ArchiveLayout from '../../../components/ArchiveLayout'
 import React, {useState} from 'react'
 import SeeMoreButton from '../../../components/SeeMoreButton'
 import {STATIC_FALLBACK} from '../../../lib/staticPaths'
-import {fetchAllEdges, TINA_PAGE_SIZE} from '../../../lib/tinaPagination'
+import {
+	fetchCollectionNodes,
+	sortByPublishedDesc,
+	filterByPublishedWindow,
+} from '../../../lib/resilientPosts'
 
 // Helper to safely extract description text from TinaCMS rich-text field
 const getDescriptionText = (description, maxLength = 75) => {
@@ -137,45 +141,41 @@ export const getStaticProps = async (ctx) => {
 	})
 
 	const categoryTitle = title.data.category.title
-	const endOfWeekStr = endOfWeek.toDateString()
 
-	const archiveEdges = await fetchAllEdges(async (after) => {
-		const {data} = await client.request({
-			query: `
-				query GetShowEvents($first: Float, $after: String, $title: String, $endOfWeek: String) {
-					archiveConnection(
-						filter: {
-							categories: {category: {category: {title: {eq: $title}}}}
-							published: {before: $endOfWeek}
-						}
-						sort: "published"
-						first: $first
-						after: $after
-					) {
-						edges {
-							node {
-								id
-								title
-								description
-								cover
-								published
-								_sys { filename }
-							}
-						}
-						pageInfo { hasNextPage endCursor }
+	// Pull every event without server-side `sort`/`filter` on `published` (which
+	// fails the whole export if any document has a stale `published` index), then
+	// keep only this show's already-aired events and order them newest-first in
+	// JS. See lib/resilientPosts.js.
+	const archiveNodes = await fetchCollectionNodes({
+		connection: 'archiveConnection',
+		fields: `
+			id
+			title
+			description
+			cover
+			published
+			categories {
+				category {
+					... on Category {
+						title
 					}
 				}
-			`,
-			variables: {
-				first: TINA_PAGE_SIZE,
-				after,
-				title: categoryTitle,
-				endOfWeek: endOfWeekStr,
-			},
-		})
-		return data.archiveConnection
+			}
+			_sys { filename }
+		`,
+		request: (query) => client.request(query),
+		fetchOne: (filename) =>
+			client.queries
+				.archive({relativePath: `${filename}.md`})
+				.then((res) => res.data.archive),
+		label: `archive/specialty-shows/${ctx.params.slug}`,
 	})
-	archiveEdges.reverse()
+	const showEvents = filterByPublishedWindow(archiveNodes, {
+		before: endOfWeek,
+	}).filter((node) =>
+		node.categories?.some((entry) => entry?.category?.title === categoryTitle)
+	)
+	const archiveEdges = sortByPublishedDesc(showEvents).map((node) => ({node}))
 
 	const {data: categoryData} = await client.request({
 		query: `{

--- a/pages/archive/specialty-shows/index.js
+++ b/pages/archive/specialty-shows/index.js
@@ -12,6 +12,7 @@ import {
 	fetchCollectionNodes,
 	sortByPublishedDesc,
 	filterByPublishedWindow,
+	filterByCategoryTitle,
 } from '../../../lib/resilientPosts'
 
 // page filtering for all specialty shows
@@ -111,7 +112,8 @@ export const getStaticProps = async () => {
 	// keep only Specialty Show events that have already aired and order them
 	// newest-first in JS. See lib/resilientPosts.js.
 	const archiveNodes = await fetchCollectionNodes({
-		connection: 'archiveConnection',
+		client,
+		collection: 'archive',
 		fields: `
 			id
 			title
@@ -127,19 +129,11 @@ export const getStaticProps = async () => {
 			}
 			_sys { filename }
 		`,
-		request: (query) => client.request(query),
-		fetchOne: (filename) =>
-			client.queries
-				.archive({relativePath: `${filename}.md`})
-				.then((res) => res.data.archive),
 		label: 'archive/specialty-shows',
 	})
-	const specialtyShowEvents = filterByPublishedWindow(archiveNodes, {
-		before: endOfWeek,
-	}).filter((node) =>
-		node.categories?.some(
-			(entry) => entry?.category?.title === 'Specialty Show'
-		)
+	const specialtyShowEvents = filterByCategoryTitle(
+		filterByPublishedWindow(archiveNodes, {before: endOfWeek}),
+		'Specialty Show'
 	)
 	const archiveEdges = sortByPublishedDesc(specialtyShowEvents).map((node) => ({
 		node,

--- a/pages/archive/specialty-shows/index.js
+++ b/pages/archive/specialty-shows/index.js
@@ -8,7 +8,11 @@ import Link from 'next/link'
 import ArchiveLayout from '../../../components/ArchiveLayout'
 import React, {useState} from 'react'
 import SeeMoreButton from '../../../components/SeeMoreButton'
-import {fetchAllEdges, TINA_PAGE_SIZE} from '../../../lib/tinaPagination'
+import {
+	fetchCollectionNodes,
+	sortByPublishedDesc,
+	filterByPublishedWindow,
+} from '../../../lib/resilientPosts'
 
 // page filtering for all specialty shows
 const SpecialtyShowsPage = (props) => {
@@ -102,40 +106,44 @@ export const getStaticProps = async () => {
 		currentDateTime.getMonth(),
 		currentDateTime.getDate() + (6 - currentDateTime.getDay())
 	)
-	const endOfWeekStr = endOfWeek.toDateString()
-
-	const archiveEdges = await fetchAllEdges(async (after) => {
-		const {data} = await client.request({
-			query: `
-				query GetSpecialtyShows($first: Float, $after: String, $endOfWeek: String) {
-					archiveConnection(
-						filter: {
-							categories: {category: {category: {title: {eq: "Specialty Show"}}}}
-							published: {before: $endOfWeek}
-						}
-						sort: "published"
-						first: $first
-						after: $after
-					) {
-						edges {
-							node {
-								id
-								title
-								description
-								cover
-								published
-								_sys { filename }
-							}
-						}
-						pageInfo { hasNextPage endCursor }
+	// Pull every event without server-side `sort`/`filter` on `published` (which
+	// fails the whole export if any document has a stale `published` index), then
+	// keep only Specialty Show events that have already aired and order them
+	// newest-first in JS. See lib/resilientPosts.js.
+	const archiveNodes = await fetchCollectionNodes({
+		connection: 'archiveConnection',
+		fields: `
+			id
+			title
+			description
+			cover
+			published
+			categories {
+				category {
+					... on Category {
+						title
 					}
 				}
-			`,
-			variables: {first: TINA_PAGE_SIZE, after, endOfWeek: endOfWeekStr},
-		})
-		return data.archiveConnection
+			}
+			_sys { filename }
+		`,
+		request: (query) => client.request(query),
+		fetchOne: (filename) =>
+			client.queries
+				.archive({relativePath: `${filename}.md`})
+				.then((res) => res.data.archive),
+		label: 'archive/specialty-shows',
 	})
-	archiveEdges.reverse()
+	const specialtyShowEvents = filterByPublishedWindow(archiveNodes, {
+		before: endOfWeek,
+	}).filter((node) =>
+		node.categories?.some(
+			(entry) => entry?.category?.title === 'Specialty Show'
+		)
+	)
+	const archiveEdges = sortByPublishedDesc(specialtyShowEvents).map((node) => ({
+		node,
+	}))
 
 	const {data: categoryData} = await client.request({
 		query: `{

--- a/pages/blog/category/[slug].js
+++ b/pages/blog/category/[slug].js
@@ -4,7 +4,10 @@ import BlogLayout from '../../../components/BlogLayout'
 import SeeMoreButton from '../../../components/SeeMoreButton'
 import React, {useState} from 'react'
 import {STATIC_FALLBACK} from '../../../lib/staticPaths'
-import {fetchAllEdges, TINA_PAGE_SIZE} from '../../../lib/tinaPagination'
+import {
+	fetchCollectionNodes,
+	sortByPublishedDesc,
+} from '../../../lib/resilientPosts'
 
 // filtering bog by category (either artist interview, show review, or album review)
 const BlogCategoryPage = (props) => {
@@ -87,36 +90,39 @@ export const getStaticProps = async (ctx) => {
 
 	const categoryTitle = title.data.category.title
 
-	const edges = await fetchAllEdges(async (after) => {
-		const {data} = await client.request({
-			query: `
-				query GetCategoryPosts($first: Float, $after: String, $title: String) {
-					blogConnection(
-						filter: {categories: {category: {category: {title: {eq: $title}}}}}
-						sort: "published"
-						first: $first
-						after: $after
-					) {
-						edges {
-							node {
-								id
-								title
-								author
-								description
-								cover
-								published
-								_sys { filename }
-							}
-						}
-						pageInfo { hasNextPage endCursor }
+	// Pull every post without server-side `sort`/`filter` on `published` (which
+	// fails the whole export if any document has a stale `published` index), then
+	// keep only this category's posts and order them newest-first in JS.
+	// See lib/resilientPosts.js.
+	const blogNodes = await fetchCollectionNodes({
+		connection: 'blogConnection',
+		fields: `
+			id
+			title
+			author
+			description
+			cover
+			published
+			categories {
+				category {
+					... on Category {
+						title
 					}
 				}
-			`,
-			variables: {first: TINA_PAGE_SIZE, after, title: categoryTitle},
-		})
-		return data.blogConnection
+			}
+			_sys { filename }
+		`,
+		request: (query) => client.request(query),
+		fetchOne: (filename) =>
+			client.queries
+				.blog({relativePath: `${filename}.md`})
+				.then((res) => res.data.blog),
+		label: `blog/category/${ctx.params.slug}`,
 	})
-	edges.reverse()
+	const categoryPosts = blogNodes.filter((node) =>
+		node.categories?.some((entry) => entry?.category?.title === categoryTitle)
+	)
+	const edges = sortByPublishedDesc(categoryPosts).map((node) => ({node}))
 
 	return {
 		props: {

--- a/pages/blog/category/[slug].js
+++ b/pages/blog/category/[slug].js
@@ -7,6 +7,7 @@ import {STATIC_FALLBACK} from '../../../lib/staticPaths'
 import {
 	fetchCollectionNodes,
 	sortByPublishedDesc,
+	filterByCategoryTitle,
 } from '../../../lib/resilientPosts'
 
 // filtering bog by category (either artist interview, show review, or album review)
@@ -95,7 +96,8 @@ export const getStaticProps = async (ctx) => {
 	// keep only this category's posts and order them newest-first in JS.
 	// See lib/resilientPosts.js.
 	const blogNodes = await fetchCollectionNodes({
-		connection: 'blogConnection',
+		client,
+		collection: 'blog',
 		fields: `
 			id
 			title
@@ -112,16 +114,9 @@ export const getStaticProps = async (ctx) => {
 			}
 			_sys { filename }
 		`,
-		request: (query) => client.request(query),
-		fetchOne: (filename) =>
-			client.queries
-				.blog({relativePath: `${filename}.md`})
-				.then((res) => res.data.blog),
 		label: `blog/category/${ctx.params.slug}`,
 	})
-	const categoryPosts = blogNodes.filter((node) =>
-		node.categories?.some((entry) => entry?.category?.title === categoryTitle)
-	)
+	const categoryPosts = filterByCategoryTitle(blogNodes, categoryTitle)
 	const edges = sortByPublishedDesc(categoryPosts).map((node) => ({node}))
 
 	return {

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -121,7 +121,8 @@ export const getStaticProps = async () => {
 	// whole export if any document has a stale `published` index) and order in
 	// JS instead. See lib/resilientPosts.js.
 	const nodes = await fetchCollectionNodes({
-		connection: 'blogConnection',
+		client,
+		collection: 'blog',
 		fields: `
 			id
 			title
@@ -130,11 +131,6 @@ export const getStaticProps = async () => {
 			description
 			_sys { filename }
 		`,
-		request: (query) => client.request(query),
-		fetchOne: (filename) =>
-			client.queries
-				.blog({relativePath: `${filename}.md`})
-				.then((res) => res.data.blog),
 		label: 'blog/index',
 	})
 

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -8,7 +8,10 @@ import Image from 'next/image'
 import React, {useState} from 'react'
 import Link from 'next/link'
 import SeeMoreButton from '../../components/SeeMoreButton.js'
-import {fetchAllEdges, TINA_PAGE_SIZE} from '../../lib/tinaPagination'
+import {
+	fetchCollectionNodes,
+	sortByPublishedDesc,
+} from '../../lib/resilientPosts'
 
 //blog home page
 export default function PostList(props) {
@@ -114,32 +117,28 @@ export default function PostList(props) {
 }
 
 export const getStaticProps = async () => {
-	const edges = await fetchAllEdges(async (after) => {
-		const {data} = await client.request({
-			query: `
-				query GetPosts($first: Float, $after: String) {
-					blogConnection(sort: "published", first: $first, after: $after) {
-						edges {
-							node {
-								id
-								title
-								cover
-								published
-								description
-								_sys { filename }
-							}
-						}
-						pageInfo { hasNextPage endCursor }
-					}
-				}
-			`,
-			variables: {first: TINA_PAGE_SIZE, after},
-		})
-		return data.blogConnection
+	// Pull every post without a server-side `sort: "published"` (which fails the
+	// whole export if any document has a stale `published` index) and order in
+	// JS instead. See lib/resilientPosts.js.
+	const nodes = await fetchCollectionNodes({
+		connection: 'blogConnection',
+		fields: `
+			id
+			title
+			cover
+			published
+			description
+			_sys { filename }
+		`,
+		request: (query) => client.request(query),
+		fetchOne: (filename) =>
+			client.queries
+				.blog({relativePath: `${filename}.md`})
+				.then((res) => res.data.blog),
+		label: 'blog/index',
 	})
 
-	// `first` walks ascending by `published`; reverse so newest renders first.
-	edges.reverse()
+	const edges = sortByPublishedDesc(nodes).map((node) => ({node}))
 
 	return {
 		props: {

--- a/pages/index.js
+++ b/pages/index.js
@@ -125,8 +125,13 @@ export const getStaticProps = async () => {
 			label: 'home/archive',
 		}),
 	])
+	// The carousels render in array order. The prior implementation used Tina's
+	// `last: N` over an ascending `published` sort, which returned the N most
+	// recent items oldest-first; take the N newest then `.reverse()` to reproduce
+	// that exact order. (Flipping to newest-first would be a separate UX change.)
 	const blogEdges = sortByPublishedDesc(blogNodes)
 		.slice(0, 6)
+		.reverse()
 		.map((node) => ({node}))
 	const archiveEdges = sortByPublishedDesc(
 		filterByPublishedWindow(archiveNodes, {
@@ -135,6 +140,7 @@ export const getStaticProps = async () => {
 		})
 	)
 		.slice(0, 30)
+		.reverse()
 		.map((node) => ({node}))
 
 	return {

--- a/pages/index.js
+++ b/pages/index.js
@@ -107,36 +107,27 @@ export const getStaticProps = async () => {
 		currentDateTime.getDate() + (8 - currentDateTime.getDay())
 	)
 
-	const request = (query) => client.request(query)
-
 	// Both collections are pulled without server-side `sort`/`filter` on
 	// `published`, then ordered and windowed in JS, so a single document with a
-	// stale `published` index can't fail the whole homepage export.
-	// See lib/resilientPosts.js.
-	const blogNodes = await fetchCollectionNodes({
-		connection: 'blogConnection',
-		fields: CAROUSEL_FIELDS,
-		request,
-		fetchOne: (filename) =>
-			client.queries
-				.blog({relativePath: `${filename}.md`})
-				.then((res) => res.data.blog),
-		label: 'home/blog',
-	})
+	// stale `published` index can't fail the whole homepage export. The two
+	// walks are independent, so run them concurrently. See lib/resilientPosts.js.
+	const [blogNodes, archiveNodes] = await Promise.all([
+		fetchCollectionNodes({
+			client,
+			collection: 'blog',
+			fields: CAROUSEL_FIELDS,
+			label: 'home/blog',
+		}),
+		fetchCollectionNodes({
+			client,
+			collection: 'archive',
+			fields: CAROUSEL_FIELDS,
+			label: 'home/archive',
+		}),
+	])
 	const blogEdges = sortByPublishedDesc(blogNodes)
 		.slice(0, 6)
 		.map((node) => ({node}))
-
-	const archiveNodes = await fetchCollectionNodes({
-		connection: 'archiveConnection',
-		fields: CAROUSEL_FIELDS,
-		request,
-		fetchOne: (filename) =>
-			client.queries
-				.archive({relativePath: `${filename}.md`})
-				.then((res) => res.data.archive),
-		label: 'home/archive',
-	})
 	const archiveEdges = sortByPublishedDesc(
 		filterByPublishedWindow(archiveNodes, {
 			after: startOfWeek,

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,11 @@ import HomepageBanner from '../components/HomepageBanner'
 import Link from 'next/link'
 import photo from '../images/logo.png'
 import Image from 'next/image'
+import {
+	fetchCollectionNodes,
+	sortByPublishedDesc,
+	filterByPublishedWindow,
+} from '../lib/resilientPosts'
 
 // home page
 export default function Home(props) {
@@ -20,36 +25,30 @@ export default function Home(props) {
 			</div>
 
 			{/* Header with WXYC logo lives here */}
-			<div className="mx-auto lg:flex hidden w-5/6 flex-col items-start justify-center pt-10 md:mb-10 md:pt-2 ">
-					<Link href="/">
-						{/* Header text parent container */}
-						<div className="mb-20 lg:mb-5 flex  w-full cursor-pointer flex-col items-center justify-center pt-20 md:flex-row md:items-end md:pt-20 lg:pt-1">
-							{/* Actual header text */}
-							<div className="flex w-full flex-col items-center justify-center md:w-3/4 md:pt-20 lg:w-2/5 lg:pt-1">
-								<Image src={photo} alt="Picture of the author" priority />
-								<h1 className=" kallistobold m-0 mx-auto text-6xl font-bold text-white no-underline">
-									89.3FM
-								</h1>
-								<div className="mt-2">
-									<h3 className="font-sans mx-auto w-full text-center text-base md:mx-0  md:text-xl lg:text-base">
-										UNC-Chapel Hill&apos;s student-run, freeform radio station
-									</h3>
-								</div>
+			<div className="mx-auto hidden w-5/6 flex-col items-start justify-center pt-10 md:mb-10 md:pt-2 lg:flex ">
+				<Link href="/">
+					{/* Header text parent container */}
+					<div className="mb-20 flex w-full  cursor-pointer flex-col items-center justify-center pt-20 md:flex-row md:items-end md:pt-20 lg:mb-5 lg:pt-1">
+						{/* Actual header text */}
+						<div className="flex w-full flex-col items-center justify-center md:w-3/4 md:pt-20 lg:w-2/5 lg:pt-1">
+							<Image src={photo} alt="Picture of the author" priority />
+							<h1 className=" kallistobold m-0 mx-auto text-6xl font-bold text-white no-underline">
+								89.3FM
+							</h1>
+							<div className="mt-2">
+								<h3 className="mx-auto w-full text-center font-sans text-base md:mx-0  md:text-xl lg:text-base">
+									UNC-Chapel Hill&apos;s student-run, freeform radio station
+								</h3>
 							</div>
 						</div>
-					</Link>
-
-					
-				</div>
+					</div>
+				</Link>
+			</div>
 
 			<div className="mx-auto flex w-5/6 flex-col gap-4">
 				<div className="-mt-5 flex w-full flex-col justify-center md:-mt-10 md:mr-10 lg:mt-5">
-					
-
 					{/* if no events: just blog posts + player */}
-					{events.length === 0 && posts && (
-						<BlogCarouselFull posts={posts} />
-					)}
+					{events.length === 0 && posts && <BlogCarouselFull posts={posts} />}
 
 					{/* if yes events: events + player */}
 					{events.length > 0 && <ArchiveCarousel events={events} />}
@@ -58,12 +57,10 @@ export default function Home(props) {
 					{events.length > 0 && posts && <BlogCarouselFull posts={posts} />}
 
 					{/* "Submit a PSA" button on mobile */}
-					<div className="lg:hidden flex w-full justify-center"> 
-						<div className="mx-auto mt-10 flex h-16 w-4/6 md:w-2/6 flex-col items-center justify-center rounded-3xl bg-gradient-to-b from-neutral-200 to-neutral-400 text-xl text-black hover:text-neutral-700 lg:mx-0 ">
+					<div className="flex w-full justify-center lg:hidden">
+						<div className="mx-auto mt-10 flex h-16 w-4/6 flex-col items-center justify-center rounded-3xl bg-gradient-to-b from-neutral-200 to-neutral-400 text-xl text-black hover:text-neutral-700 md:w-2/6 lg:mx-0 ">
 							<div>
-								<a href="mailto:psa@wxyc.org">
-									Submit a PSA!
-								</a>
+								<a href="mailto:psa@wxyc.org">Submit a PSA!</a>
 							</div>
 						</div>
 					</div>
@@ -78,6 +75,25 @@ export default function Home(props) {
 	)
 }
 
+// Shared node selection for the blog + archive carousels. Both render category
+// chips, so both pull the nested category reference.
+const CAROUSEL_FIELDS = `
+	id
+	title
+	cover
+	published
+	description
+	categories {
+		category {
+			... on Category {
+				_sys { filename }
+				title
+			}
+		}
+	}
+	_sys { filename }
+`
+
 export const getStaticProps = async () => {
 	const currentDateTime = new Date()
 	const startOfWeek = new Date(
@@ -90,66 +106,52 @@ export const getStaticProps = async () => {
 		currentDateTime.getMonth(),
 		currentDateTime.getDate() + (8 - currentDateTime.getDay())
 	)
-	const {data} = await client.request({
-		query: `
-    query getContent($startOfWeek: String, $endOfWeek: String)
-    {    
-        blogConnection(sort: "published", last:6){
-          edges {
-            node {
-              id
-              title
-              cover
-              published
-              description
-			  categories {
-				category {
-		  			... on Category {
-						_sys {
-							filename
-						}
-						title
-					}
-  				}
-			}
-              _sys {
-                filename
-              }
-            }
-          }
-        },
-       
-      archiveConnection(filter: {published: {after: $startOfWeek, before: $endOfWeek}}, sort: "published", last:30) {
-        edges {
-          node {
-            id
-            title
-            cover
-            published
-			categories {
-				category {
-		  			... on Category {
-						_sys {
-							filename
-						}
-						title
-					}
-  				}
-			}
-            _sys {
-              filename
-            }
-          }
-        }
-      },
-  }
-    
-    `,
-		variables: {
-			endOfWeek: endOfWeek.toDateString(),
-			startOfWeek: startOfWeek.toDateString(),
-		},
-	})
 
-	return {props: {data}}
+	const request = (query) => client.request(query)
+
+	// Both collections are pulled without server-side `sort`/`filter` on
+	// `published`, then ordered and windowed in JS, so a single document with a
+	// stale `published` index can't fail the whole homepage export.
+	// See lib/resilientPosts.js.
+	const blogNodes = await fetchCollectionNodes({
+		connection: 'blogConnection',
+		fields: CAROUSEL_FIELDS,
+		request,
+		fetchOne: (filename) =>
+			client.queries
+				.blog({relativePath: `${filename}.md`})
+				.then((res) => res.data.blog),
+		label: 'home/blog',
+	})
+	const blogEdges = sortByPublishedDesc(blogNodes)
+		.slice(0, 6)
+		.map((node) => ({node}))
+
+	const archiveNodes = await fetchCollectionNodes({
+		connection: 'archiveConnection',
+		fields: CAROUSEL_FIELDS,
+		request,
+		fetchOne: (filename) =>
+			client.queries
+				.archive({relativePath: `${filename}.md`})
+				.then((res) => res.data.archive),
+		label: 'home/archive',
+	})
+	const archiveEdges = sortByPublishedDesc(
+		filterByPublishedWindow(archiveNodes, {
+			after: startOfWeek,
+			before: endOfWeek,
+		})
+	)
+		.slice(0, 30)
+		.map((node) => ({node}))
+
+	return {
+		props: {
+			data: {
+				blogConnection: {edges: blogEdges},
+				archiveConnection: {edges: archiveEdges},
+			},
+		},
+	}
 }


### PR DESCRIPTION
Closes #194

## Why

Every push that touches content has been failing the **Deploy Next.js site to Pages** workflow for weeks. Editor changes commit fine but never reach wxyc.org — new posts don't appear, takedowns don't take effect — because the static export crashes during prerender.

The cause: every listing query used Tina's server-side `sort: "published"` (and the archive listings `filter: {published: ...}`). Serving a sorted/filtered connection makes Tina Cloud read each doc's **indexed** `published` value and throw `Error querying file <name> from collection <c>` for any doc whose index is missing/stale, aborting the prerender of `/` and `/blog` and failing the whole build. The per-`[slug]` pages never sort by published, which is why all 235 of them build while only the sorted listings die. Editors trip the index drift routinely by creating/deleting/re-saving posts.

## What

- **`lib/resilientPosts.js`** (new):
  - `fetchCollectionNodes()` walks the collection **unsorted** for display fields (cheap happy path); on failure falls back to a filename-only walk + per-document fetch that skips and logs any doc that still fails — the two query shapes proven to resolve against a broken index.
  - `sortByPublishedDesc()` / `filterByPublishedWindow()` order and window in JS, tolerating missing/invalid dates.
- Converted every `sort:"published"` / `filter:{published}` listing to use the helper, moving category and week-window filtering to JS: homepage, `/blog`, `/blog/category/[slug]`, `/archive`, `/archive/events`, `/archive/specialty-shows`, `/archive/specialty-shows/[slug]`.

A single bad document can now demote or drop itself from a listing but can never freeze the deploy. This works **without** a Tina Cloud re-index; re-indexing only restores the cheap happy path.

## Verification

- `npm test` — 67 pass (8 new in `__tests__/resilientPosts.test.js` cover sort, window, and the per-document fallback).
- Local-mode build (the PR-CI path: `tinacms dev` + `next build`) completes green, all 235 pages, **zero** prerender/export errors. Homepage and `/blog` render newest-first; the previously-stuck gov-ball review post now builds into the listing.

## Notes / follow-ups (separate)

- Re-index / `tinacms audit` the Tina Cloud project to restore the cheap happy path (needs cloud credentials).
- Editorial cleanup of the duplicate "hiring for summer" drafts — now removable through the CMS once this deploys.