### PR TITLE
feat: photographer credit for blog and archive cover images

### DIFF
--- a/__tests__/coverImage.test.jsx
+++ b/__tests__/coverImage.test.jsx
@@ -26,6 +26,13 @@ describe('CoverImage', () => {
 		expect(container.querySelector('figcaption')).toBeNull()
 	})
 
+	it('does not render a caption when credit is only whitespace', () => {
+		const {container} = render(
+			<CoverImage src="/uploads/show.jpg" credit="   " />
+		)
+		expect(container.querySelector('figcaption')).toBeNull()
+	})
+
 	it('applies passed className and width to the image', () => {
 		render(
 			<CoverImage

--- a/__tests__/coverImage.test.jsx
+++ b/__tests__/coverImage.test.jsx
@@ -1,0 +1,56 @@
+import {describe, it, expect, afterEach} from 'vitest'
+import {render, screen, cleanup} from '@testing-library/react'
+import CoverImage from '../components/CoverImage'
+
+describe('CoverImage', () => {
+	afterEach(() => cleanup())
+
+	it('renders the cover image with the given src', () => {
+		render(<CoverImage src="/uploads/show.jpg" />)
+		const img = screen.getByRole('img')
+		expect(img.getAttribute('src')).toBe('/uploads/show.jpg')
+	})
+
+	it('renders a photo credit caption when credit is provided', () => {
+		render(<CoverImage src="/uploads/show.jpg" credit="Juana Molina" />)
+		expect(screen.getByText('Photo by Juana Molina')).toBeDefined()
+	})
+
+	it('does not render a caption when no credit is provided', () => {
+		const {container} = render(<CoverImage src="/uploads/show.jpg" />)
+		expect(container.querySelector('figcaption')).toBeNull()
+	})
+
+	it('does not render a caption when credit is an empty string', () => {
+		const {container} = render(<CoverImage src="/uploads/show.jpg" credit="" />)
+		expect(container.querySelector('figcaption')).toBeNull()
+	})
+
+	it('applies passed className and width to the image', () => {
+		render(
+			<CoverImage
+				src="/uploads/show.jpg"
+				className="object-cover"
+				width="650px"
+			/>
+		)
+		const img = screen.getByRole('img')
+		expect(img.getAttribute('width')).toBe('650px')
+		expect(img.className).toContain('object-cover')
+	})
+
+	it('passes width and height through to the image', () => {
+		render(<CoverImage src="/uploads/show.jpg" width="400" height="400" />)
+		const img = screen.getByRole('img')
+		expect(img.getAttribute('width')).toBe('400')
+		expect(img.getAttribute('height')).toBe('400')
+	})
+
+	it('applies figureClassName to the wrapping figure', () => {
+		const {container} = render(
+			<CoverImage src="/uploads/show.jpg" figureClassName="my-2" />
+		)
+		const figure = container.querySelector('figure')
+		expect(figure.className).toContain('my-2')
+	})
+})

--- a/components/CoverImage.jsx
+++ b/components/CoverImage.jsx
@@ -1,0 +1,48 @@
+/**
+ * Cover image with an optional photographer credit.
+ *
+ * Renders the image inside a <figure>; when a non-empty `credit` is supplied a
+ * <figcaption> reading "Photo by {credit}" is shown beneath it. Layout of the
+ * wrapper is left to the caller via `figureClassName`, so the same caption
+ * treatment works for the centered blog cover and the left-aligned archive
+ * cover. Content without a credit renders exactly as a bare image would.
+ *
+ * @param {Object} props
+ * @param {string} props.src - Image source URL.
+ * @param {string} [props.credit] - Photographer to credit. Omitted/empty hides the caption.
+ * @param {string} [props.alt] - Alt text for the image.
+ * @param {string} [props.width] - Image width attribute.
+ * @param {string} [props.height] - Image height attribute.
+ * @param {string} [props.className] - Classes applied to the <img>.
+ * @param {string} [props.figureClassName] - Classes applied to the wrapping <figure>.
+ * @param {string} [props.captionClassName] - Classes applied to the <figcaption>.
+ */
+const CoverImage = ({
+	src,
+	credit,
+	alt = '',
+	width,
+	height,
+	className,
+	figureClassName = '',
+	captionClassName = 'mt-2 text-sm italic text-neutral-400',
+}) => {
+	const hasCredit = Boolean(credit && credit.trim())
+
+	return (
+		<figure className={figureClassName}>
+			<img
+				src={src}
+				alt={alt}
+				width={width}
+				height={height}
+				className={className}
+			/>
+			{hasCredit && (
+				<figcaption className={captionClassName}>Photo by {credit}</figcaption>
+			)}
+		</figure>
+	)
+}
+
+export default CoverImage

--- a/pages/archive/[slug].js
+++ b/pages/archive/[slug].js
@@ -3,6 +3,7 @@ import {client} from '../../tina/__generated__/client'
 import {TinaMarkdown} from 'tinacms/dist/rich-text'
 import Link from 'next/link'
 import ArchiveLayout from '../../components/ArchiveLayout'
+import CoverImage from '../../components/CoverImage'
 import {AiFillTag} from 'react-icons/ai'
 import Head from 'next/head'
 import {STATIC_FALLBACK} from '../../lib/staticPaths'
@@ -38,12 +39,12 @@ const EventPage = (props) => {
 						</p>
 						<p className="mb-5 text-xl">{displayDate}</p>
 
-						<img
-							className="my-2"
+						<CoverImage
 							src={data.archive.cover}
-							alt=""
+							credit={data.archive.coverCredit}
 							width="400"
 							height="400"
+							figureClassName="my-2"
 						/>
 
 						<article className="prose mt-3 text-white prose-a:text-slate-700 prose-strong:text-slate-700">

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -61,7 +61,7 @@ const PostPage = (props) => {
 					credit={data.blog.coverCredit}
 					width="650px"
 					className="max-h-[40rem] object-cover"
-					figureClassName="my-8 mb-20 flex flex-col items-center"
+					figureClassName="my-8 mb-20 flex w-full flex-col items-center"
 				/>
 
 				<article className="prose prose-lg bg-neutral-800 bg-opacity-70 px-5 py-2 text-white prose-h1:text-slate-500 prose-h2:text-slate-500 prose-h3:text-white prose-a:text-slate-700 prose-strong:text-slate-400 prose-em:italic prose-li:mb-1 lg:max-w-[60%]">

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -3,6 +3,7 @@ import {client} from '../../tina/__generated__/client'
 import {TinaMarkdown} from 'tinacms/dist/rich-text'
 import Link from 'next/link'
 import BlogLayout from '../../components/BlogLayout'
+import CoverImage from '../../components/CoverImage'
 import {STATIC_FALLBACK} from '../../lib/staticPaths'
 import {fetchAllEdges, TINA_PAGE_SIZE} from '../../lib/tinaPagination'
 
@@ -55,11 +56,12 @@ const PostPage = (props) => {
 				<p className="my-9 text-lg italic lg:w-3/6 xl:w-3/5">
 					{data.blog.description}
 				</p>
-				<img
+				<CoverImage
 					src={data.blog.cover}
-					alt=""
+					credit={data.blog.coverCredit}
 					width="650px"
-					className="my-8 mb-20 max-h-[40rem] object-cover"
+					className="max-h-[40rem] object-cover"
+					figureClassName="my-8 mb-20 flex flex-col items-center"
 				/>
 
 				<article className="prose prose-lg bg-neutral-800 bg-opacity-70 px-5 py-2 text-white prose-h1:text-slate-500 prose-h2:text-slate-500 prose-h3:text-white prose-a:text-slate-700 prose-strong:text-slate-400 prose-em:italic prose-li:mb-1 lg:max-w-[60%]">

--- a/tina/collections/archive.js
+++ b/tina/collections/archive.js
@@ -44,6 +44,13 @@ export default {
 			label: 'Cover Image',
 		},
 		{
+			type: 'string',
+			name: 'coverCredit',
+			label: 'Cover Photo Credit',
+			description:
+				'Photographer to credit beneath the cover image (e.g. "Jane Doe"). Leave blank for no credit.',
+		},
+		{
 			type: 'object',
 			list: true,
 			name: 'categories',

--- a/tina/collections/blog.js
+++ b/tina/collections/blog.js
@@ -38,6 +38,13 @@ export default {
 			label: 'Cover Image',
 		},
 		{
+			type: 'string',
+			name: 'coverCredit',
+			label: 'Cover Photo Credit',
+			description:
+				'Photographer to credit beneath the cover image (e.g. "Jane Doe"). Leave blank for no credit.',
+		},
+		{
 			type: 'object',
 			list: true,
 			name: 'categories',


### PR DESCRIPTION
## What

Adds an optional **"Cover Photo Credit"** field to the Blog and Archive collections so editors can attribute a cover photo to its photographer. When filled, the post/event page renders a `Photo by {name}` caption beneath the cover image; when blank, the page renders exactly as before.

Requested by a DJ who didn't want to publish cover photos without crediting the original photographer.

## Changes

- **Schema:** `coverCredit` string field added to `tina/collections/blog.js` and `tina/collections/archive.js`, directly under Cover Image, with editor helper text. It flows into the generated GraphQL query automatically on `tinacms build`.
- **Component:** new `components/CoverImage.jsx` — layout-agnostic image + optional `<figcaption>`. The caller supplies the `<figure>`/caption layout classes, so one component serves the centered blog cover and the left-aligned archive cover.
- **Pages:** `pages/blog/[slug].js` and `pages/archive/[slug].js` now render `<CoverImage>` in place of a bare `<img>`.
- **Tests:** `__tests__/coverImage.test.jsx` — 7 unit tests covering caption presence/absence (including whitespace-only credit) and `src`/`width`/`height`/`className`/`figureClassName` passthrough.

## Backward compatibility

Existing blog posts and archive events have no `coverCredit`, so no caption renders and the layout is unchanged.

## Testing

- `npm test` — 81/81 pass (7 new)
- `prettier --check` — clean
- `next lint` — clean (only the repo-wide pre-existing `<img>`-vs-`next/image` warning, matching existing cover markup)
- Full `tinacms build && next build` not run locally (needs TinaCMS cloud credentials); the PR build workflow exercises it in Tina local mode.

## Out of scope

A default/fallback cover image for posts with no photo at all — deferred.

Closes #201
