### PR TITLE
docs: note Cloudflare apex proxy and expected GitHub Pages domain warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 <img width="1146" alt="image" src="https://github.com/haowens/website/assets/69762131/75c67f8a-f69b-4d54-934d-ce528c9c6964">
 <p>[the development of this site is brought to you by the easily accessible assortment of photos of Adrianne Lenker that live on my desktop]</p>
 
+<h3>DNS &amp; hosting (do not "fix" the Pages domain warning)</h3>
+<p><code>wxyc.org</code> and <code>www.wxyc.org</code> are proxied through Cloudflare (orange-cloud) rather than pointing their DNS records directly at GitHub Pages. Cloudflare forwards the <code>Host</code> header to GitHub Pages as the origin, so the site is still built and served by this repo's Pages deploy exactly as before &mdash; Cloudflare just sits in front of it (this is what lets us attach edge Workers to the apex).</p>
+<p>Because the public A/AAAA records no longer resolve to GitHub's Pages IPs (they resolve to Cloudflare's edge), <b>repo Settings &rarr; Pages will show a warning that the custom domain's DNS does not point at GitHub Pages.</b> This warning is expected and cosmetic &mdash; the site works. <b>Do not change the DNS records back to GitHub's IPs, and do not clear the custom-domain field in Settings &rarr; Pages</b> (the custom domain lives only there; there is no <code>CNAME</code> file in the repo). Reverting either would break the Cloudflare proxy in front of the apex. If you need to take Cloudflare out of the path, toggle the apex + <code>www</code> records from orange (Proxied) back to gray (DNS only) in the Cloudflare dashboard.</p>
+
 <h3>Wishlist</h3>
 <ul>
 <li>Setlist component for blog posts</li>


### PR DESCRIPTION
Part of #209 (apex cutover stage 1). Satisfies the "README note about the expected GitHub Pages domain-check warning" acceptance criterion.

## Context

Stage 1 of the apex cutover proxies `wxyc.org` + `www.wxyc.org` through Cloudflare (orange-cloud) so we can later attach edge Workers to the apex (On Tour share links + AASA). Once the DNS records go orange-cloud, they no longer resolve to GitHub's Pages IPs, so **repo Settings → Pages will warn that the custom domain's DNS does not point at GitHub Pages.** The site still works — Cloudflare forwards the `Host` header to Pages as the origin.

This adds a short README section documenting that the warning is expected and cosmetic, and that neither the DNS records nor the Pages custom-domain field (there is no `CNAME` file in the repo) should be reverted, so nobody "fixes" the DNS back and breaks the proxy.

## Merge timing

Per the stage-1 runbook, this should merge **in the same change window as the orange-cloud flip** so the doc lands alongside the DNS change. It is queued and ready; hold until the flip.

## Not in scope

No DNS/Cloudflare changes are in this PR — the flip, preflight, soak, and September cert-renewal re-check remain on #209 and are human-operated. This PR is docs only; #209 stays open until those complete.