### PR TITLE
Add wxyc.org/donate page + Header nav entry

### DIFF
--- a/__tests__/donatePage.test.jsx
+++ b/__tests__/donatePage.test.jsx
@@ -34,13 +34,42 @@ describe('Donate page', () => {
 
 	it('discloses how funds are used', () => {
 		render(<Donate />)
-		expect(screen.getByText(/equipment/)).toBeDefined()
-		expect(screen.getByText(/music library/)).toBeDefined()
-		expect(screen.getByText(/broadcasting/)).toBeDefined()
+		// App Store Review Guideline 3.2.1 requires the linked page to say what
+		// the money does. Bind all three terms to the one use-of-funds paragraph
+		// so the assertion cannot be satisfied by the words turning up
+		// incidentally elsewhere on the page.
+		const useOfFunds = screen.getByText(/Your donation supports/)
+		expect(useOfFunds.textContent).toMatch(/equipment/)
+		expect(useOfFunds.textContent).toMatch(/music library/)
+		expect(useOfFunds.textContent).toMatch(/broadcasting/)
 	})
 
-	it('does not render a payment button', () => {
+	it('keeps the disclosure adjacent to the ask, in matching type size', () => {
 		render(<Donate />)
-		expect(screen.queryByRole('button')).toBeNull()
+		const ask = screen.getByText(/Please consider making a gift/)
+		const disclosure = screen.getByText(
+			/is not a 501\(c\)\(3\) tax-exempt organization/
+		)
+		// Federal safe-harbor placement: the disclosure sits immediately after the
+		// ask, so nothing — least of all a future payment embed — can be wedged
+		// between them.
+		expect(disclosure.previousElementSibling).toBe(ask)
+		// ...and at the same type size. Both are unstyled <p> inside the same
+		// `prose prose-lg` block; a divergent class on either (say `text-sm` on
+		// the disclosure) would break the safe harbor.
+		expect(disclosure.tagName).toBe(ask.tagName)
+		expect(disclosure.className).toBe(ask.className)
+	})
+
+	it('renders no payment affordance until the SEB board picks a platform', () => {
+		const {container} = render(<Donate />)
+		// A payment path can arrive as a button, a form post, a hosted-checkout
+		// iframe, or a bare link to a processor — querying the `button` role
+		// alone would wave the last three straight through.
+		expect(container.querySelector('button, form, iframe')).toBeNull()
+		const offsiteLinks = Array.from(container.querySelectorAll('a[href]'))
+			.map((a) => a.getAttribute('href'))
+			.filter((href) => !href.startsWith('/'))
+		expect(offsiteLinks).toEqual([])
 	})
 })

--- a/__tests__/donatePage.test.jsx
+++ b/__tests__/donatePage.test.jsx
@@ -1,0 +1,46 @@
+import {describe, it, expect, vi, afterEach} from 'vitest'
+import {render, screen, cleanup} from '@testing-library/react'
+
+vi.mock('next/head', () => ({
+	default: ({children}) => <>{children}</>,
+}))
+
+const Donate = (await import('../pages/donate')).default
+
+describe('Donate page', () => {
+	afterEach(() => cleanup())
+
+	it('carries the federal safe-harbor non-deductibility statement', () => {
+		render(<Donate />)
+		expect(
+			screen.getByText(/is not a 501\(c\)\(3\) tax-exempt organization/)
+		).toBeDefined()
+		expect(
+			screen.getByText(
+				/Contributions are not deductible as charitable contributions for federal income tax purposes/
+			)
+		).toBeDefined()
+	})
+
+	it('names Student Educational Broadcasting, Inc. as the soliciting organization, not UNC', () => {
+		render(<Donate />)
+		expect(
+			screen.getAllByText(/Student Educational Broadcasting, Inc\./).length
+		).toBeGreaterThan(0)
+		expect(
+			screen.getByText(/not to the University of North Carolina at Chapel Hill/)
+		).toBeDefined()
+	})
+
+	it('discloses how funds are used', () => {
+		render(<Donate />)
+		expect(screen.getByText(/equipment/)).toBeDefined()
+		expect(screen.getByText(/music library/)).toBeDefined()
+		expect(screen.getByText(/broadcasting/)).toBeDefined()
+	})
+
+	it('does not render a payment button', () => {
+		render(<Donate />)
+		expect(screen.queryByRole('button')).toBeNull()
+	})
+})

--- a/components/Header.js
+++ b/components/Header.js
@@ -239,6 +239,18 @@ const Header = () => {
 							</Link>
 						</div>
 
+						<div className="ml-10 mt-8 flex h-8 text-3xl">
+							<Link
+								href="/donate"
+								legacyBehavior={false}
+								className="cursor-pointer"
+								rel="noopener noreferrer"
+								onClick={toggleMenu}
+							>
+								Donate
+							</Link>
+						</div>
+
 						<div className="mb-10 ml-10 mt-8 flex h-8 text-3xl">
 							<Link
 								href="https://merch.wxyc.org/"
@@ -331,6 +343,14 @@ const Header = () => {
 								<a className="flex h-12 grow items-center justify-center">
 									<p className="cursor-pointer text-base no-underline hover:text-blue-300">
 										Contact
+									</p>
+								</a>
+							</Link>
+
+							<Link href="/donate" legacyBehavior>
+								<a className="flex h-12 grow items-center justify-center">
+									<p className="cursor-pointer text-base no-underline hover:text-blue-300">
+										Donate
 									</p>
 								</a>
 							</Link>

--- a/pages/donate.jsx
+++ b/pages/donate.jsx
@@ -20,7 +20,7 @@ const Donate = () => {
 			<div className="mx-auto w-full px-4 pb-16 sm:w-5/6">
 				<h1 className="kallisto mb-6 text-5xl">Donate</h1>
 
-				<div className="prose prose-lg max-w-none text-white">
+				<div className="prose prose-lg text-white">
 					<p>
 						WXYC 89.3 FM has been Chapel Hill&apos;s student-run, freeform radio
 						station since 1977, powered by student DJs and listener support.
@@ -43,7 +43,9 @@ const Donate = () => {
 						one another, in matching type size, directly above the future
 						payment area — the federal safe-harbor placement for a
 						non-deductibility statement. Keep them adjacent if this section is
-						ever reordered.
+						ever reordered; inserting the payment embed between them, or
+						shrinking the disclosure's type, breaks the safe harbor.
+						`__tests__/donatePage.test.jsx` pins both properties.
 					*/}
 					<p>
 						Please consider making a gift to Student Educational Broadcasting,

--- a/pages/donate.jsx
+++ b/pages/donate.jsx
@@ -1,0 +1,74 @@
+import Head from 'next/head'
+
+// Donate page — the landing destination the iOS and Android apps bake in at
+// compile time as their fallback donate URL (https://wxyc.org/donate). It has
+// to exist before either app ships, even though the SEB board has not yet
+// picked a donation platform. There is deliberately no payment button here:
+// once the board decides, a payment link or embed can be added to this page
+// without an app release.
+const Donate = () => {
+	return (
+		<>
+			<Head>
+				<title>Donate | WXYC</title>
+				<meta
+					name="description"
+					content="Support WXYC 89.3 FM, Chapel Hill's student-run, freeform radio station."
+				/>
+			</Head>
+
+			<div className="mx-auto w-full px-4 pb-16 sm:w-5/6">
+				<h1 className="kallisto mb-6 text-5xl">Donate</h1>
+
+				<div className="prose prose-lg max-w-none text-white">
+					<p>
+						WXYC 89.3 FM has been Chapel Hill&apos;s student-run, freeform radio
+						station since 1977, powered by student DJs and listener support.
+					</p>
+
+					<p>
+						Your donation supports station operations: maintaining our broadcast
+						equipment, growing our music library, and keeping WXYC 89.3 FM
+						broadcasting.
+					</p>
+
+					<p>
+						Donations to WXYC go to Student Educational Broadcasting, Inc.
+						(SEB), the North Carolina nonprofit that holds WXYC&apos;s broadcast
+						license — not to the University of North Carolina at Chapel Hill.
+					</p>
+
+					{/*
+						The ask and the non-deductibility disclosure below sit adjacent to
+						one another, in matching type size, directly above the future
+						payment area — the federal safe-harbor placement for a
+						non-deductibility statement. Keep them adjacent if this section is
+						ever reordered.
+					*/}
+					<p>
+						Please consider making a gift to Student Educational Broadcasting,
+						Inc. to support WXYC.
+					</p>
+					{/*
+						PENDING CPA SIGN-OFF: draft wording only. Replace verbatim once
+						SEB's accountant/counsel approves the final language. Do not adjust
+						size, placement, or wording without that sign-off.
+					*/}
+					<p>
+						Student Educational Broadcasting, Inc. is not a 501(c)(3) tax-exempt
+						organization. Contributions are not deductible as charitable
+						contributions for federal income tax purposes.
+					</p>
+
+					{/*
+						No payment button yet — the SEB board has not chosen a donation
+						platform. This is where the payment link or embed will go once
+						that decision lands.
+					*/}
+				</div>
+			</div>
+		</>
+	)
+}
+
+export default Donate


### PR DESCRIPTION
Adds `pages/donate.jsx` and a "Donate" nav entry in both the mobile and desktop headers.

## Why now

The iOS and Android apps bake `https://wxyc.org/donate` in as their compile-time fallback donate destination, so the page has to be live before either app ships — a Donate row that 404s is worse than no Donate row. Shipping the page ahead of the payment integration also means the payment link or embed can land later without an app release, since the apps only ever point at this URL.

## Disclosure requirements this page satisfies

The donation copy here is legally load-bearing, not stylistic. It follows from Student Educational Broadcasting, Inc. (SEB) — the North Carolina nonprofit that holds WXYC's broadcast license — having no IRS 501(c)(3) determination:

1. **Federal safe-harbor non-deductibility statement.** "Student Educational Broadcasting, Inc. is not a 501(c)(3) tax-exempt organization. Contributions are not deductible as charitable contributions for federal income tax purposes." It renders in the same type size as the ask and immediately adjacent to it, above where a payment button would sit — the safe-harbor placement. A code comment marks the adjacency as load-bearing so a future reorder does not separate them. Gifts are never described as "tax-deductible" anywhere on the page.
2. **SEB, not UNC, named as the soliciting organization** (UNC Policy Manual 600.2.5.2[R]). The page states donations go to SEB and explicitly not to the University of North Carolina at Chapel Hill.
3. **Use-of-funds sentence** (App Store Review Guideline 3.2.1, which requires the page an app links to for donations to disclose how funds are used). The page names broadcast equipment maintenance, the music library, and keeping the station broadcasting.

## Open items, deliberately deferred

- **Copy is pending CPA sign-off.** The disclosure wording is a draft, marked in-file with a `PENDING CPA SIGN-OFF` comment; it gets replaced verbatim once SEB's accountant/counsel approves the final language.
- **No payment button or embed yet.** The SEB board has not picked a donation platform. A code comment marks exactly where the payment link or embed goes; it lands in a follow-up once that decision is made. `__tests__/donatePage.test.jsx` pins the absence of a payment path — no button, form, iframe, or off-site link — so it stays deliberate rather than accidental.
- **Merge gate, tracked outside this repo:** this page carries an active ask, so it should not go live until SEB's pending NC Secretary of State charitable-solicitation exemption request is resolved. Worth confirming that has landed before merging, since merging publishes the page.

## Tests

`__tests__/donatePage.test.jsx` (Vitest + RTL) pins four assertions: the safe-harbor non-deductibility statement, SEB named as the soliciting organization rather than UNC, the use-of-funds sentence, and that no payment button renders. The test file is `.jsx` because Vitest in this repo cannot transform JSX inside `.js` files.

The Footer is deliberately untouched — it carries no sibling page-nav list for a Donate link to join.

Closes #220

## Related

Sibling slices of the WXYC donation-button initiative (contract, backend, clients):

- https://github.com/WXYC/wxyc-shared/issues/338 — contract: `AppConfig.donateUrl` + `donateEnabled`
- https://github.com/WXYC/Backend-Service/issues/2111 — `GET /config` serves both fields (dark)
- https://github.com/WXYC/wxyc-ios-64/issues/912 — iOS Donate row + `/config` launch plumbing (implemented in https://github.com/WXYC/wxyc-ios-64/pull/913)
- https://github.com/WXYC/WXYC-Android/issues/27 — Android Donate button (hardcoded URL v1)
