### PR TITLE
feat(nav): repoint every wxyc.info link at its wxyc.org successor page

### DIFF
--- a/__tests__/wxycInfoLinks.test.js
+++ b/__tests__/wxycInfoLinks.test.js
@@ -1,0 +1,116 @@
+/**
+ * Turndown guard for the wxyc.info -> wxyc.org link cutover (WXYC/website#214).
+ *
+ * tubafrenzy — which serves every `wxyc.info/playlists/*` page — goes dark at the
+ * 2026-08-31 cutover (WXYC/wiki#93). After that date any surviving link into
+ * wxyc.info is a dead link for a listener, so the repo must not carry one.
+ *
+ * Deliberately a source-level check rather than a render test: `Header.js` and
+ * `DropdownMenu.js` hold JSX in `.js` files, which this repo's vitest transform
+ * does not accept, and the third link site is TinaCMS-managed `.mdx` content that
+ * no component test would ever cover.
+ *
+ * Prose mentions of wxyc.info are allowed on purpose. The successor pages each
+ * carry a docblock naming the page they replace, and README.md does the same;
+ * that is accurate provenance and deleting it to satisfy a grep would lose
+ * history. Only *link targets* are policed.
+ */
+import {describe, it, expect} from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const SKIP_DIRS = new Set([
+	'node_modules',
+	'.next',
+	'out',
+	'.git',
+	'.vercel',
+	'public',
+])
+const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.md', '.mdx'])
+
+/** JSX/HTML `href="..."` attributes. */
+const HREF_PATTERN = /href=["']([^"']+)["']/g
+/** Markdown `[text](target)` links. */
+const MARKDOWN_LINK_PATTERN = /\]\(([^)\s]+)/g
+
+function sourceFiles(dir = ROOT) {
+	return fs.readdirSync(dir, {withFileTypes: true}).flatMap((entry) => {
+		const full = path.join(dir, entry.name)
+		if (entry.isDirectory()) {
+			return SKIP_DIRS.has(entry.name) ? [] : sourceFiles(full)
+		}
+		return SOURCE_EXTENSIONS.has(path.extname(entry.name)) ? [full] : []
+	})
+}
+
+/** Every link target in `content`, paired with its 1-based line number. */
+function linkTargets(content) {
+	const targets = []
+	content.split('\n').forEach((line, index) => {
+		for (const pattern of [HREF_PATTERN, MARKDOWN_LINK_PATTERN]) {
+			pattern.lastIndex = 0
+			let match
+			while ((match = pattern.exec(line)) !== null) {
+				targets.push({target: match[1], line: index + 1})
+			}
+		}
+	})
+	return targets
+}
+
+/** The `pages/` file a route resolves to, or null when the route has no page. */
+function resolvePage(route) {
+	const base = path.join(ROOT, 'pages', route.replace(/^\//, ''))
+	const candidates = [
+		...['.js', '.jsx', '.ts', '.tsx'].map((ext) => `${base}${ext}`),
+		...['.js', '.jsx', '.ts', '.tsx'].map((ext) =>
+			path.join(base, `index${ext}`)
+		),
+	]
+	return candidates.find((candidate) => fs.existsSync(candidate)) ?? null
+}
+
+describe('wxyc.info link cutover', () => {
+	it('leaves no link pointing into wxyc.info', () => {
+		const violations = sourceFiles().flatMap((file) =>
+			linkTargets(fs.readFileSync(file, 'utf8'))
+				.filter(({target}) => /wxyc\.info/i.test(target))
+				.map(
+					({target, line}) =>
+						`${path.relative(ROOT, file)}:${line} -> ${target}`
+				)
+		)
+		expect(violations).toEqual([])
+	})
+
+	// The four link sites inventoried on WXYC/website#214, each with the
+	// wxyc.info page it replaces.
+	it.each([
+		['components/Header.js', '/playlist', 'wxyc.info/playlists/recent'],
+		['components/DropdownMenu.js', '/playlist', 'wxyc.info/playlists/recent'],
+		[
+			'content/page/programming.mdx',
+			'/playlists/archive',
+			'wxyc.info/playlists/radioWeek',
+		],
+		[
+			'content/page/programming.mdx',
+			'/airplay-search',
+			'wxyc.info/playlists/searchPlaylists',
+		],
+	])('%s links to %s in place of %s', (file, route) => {
+		const targets = linkTargets(
+			fs.readFileSync(path.join(ROOT, file), 'utf8')
+		).map(({target}) => target)
+		expect(targets).toContain(route)
+	})
+
+	it.each([['/playlist'], ['/playlists/archive'], ['/airplay-search']])(
+		'%s resolves to a page that exists',
+		(route) => {
+			expect(resolvePage(route)).not.toBeNull()
+		}
+	)
+})

--- a/components/DropdownMenu.js
+++ b/components/DropdownMenu.js
@@ -45,12 +45,7 @@ const DropdownMenu = () => {
 					</div>
 					<div className="text-medium flex w-full items-center justify-center rounded-md px-4 py-2  text-white hover:text-blue-300">
 						<Menu.Item>
-							<Link
-								href="http://www.wxyc.info/playlists/recent"
-								target="_blank"
-								legacyBehavior={false}
-							>
-								{/* Until new flowsheet is deployed: <Link href="/playlist" legacyBehavior={false}> */}
+							<Link href="/playlist" legacyBehavior={false}>
 								Live playlist
 							</Link>
 						</Menu.Item>

--- a/components/Header.js
+++ b/components/Header.js
@@ -104,8 +104,9 @@ const Header = () => {
 									<div className="mb-2 flex w-full text-nowrap text-white">
 										<Menu.Item>
 											<Link
-												href="http://www.wxyc.info/playlists/recent"
-												target="_blank"
+												href="/playlist"
+												legacyBehavior={false}
+												onClick={toggleMenu}
 											>
 												Live playlist
 											</Link>

--- a/content/page/programming.mdx
+++ b/content/page/programming.mdx
@@ -51,6 +51,6 @@ A spotlight on beat-oriented music, dance culture, and the art of live mixing. T
 
 Want to listen to a show from the past two weeks? Hit up the [WXYC Archive Player](https://archive.wxyc.org/).
 
-Just want the playlist from any show going back to 2009? Go to our [show archives](http://wxyc.info/playlists/radioWeek).
+Just want the playlist from any show going back to 2009? Go to our [show archives](/playlists/archive).
 
-Have a specific song, artist, album, or label in mind? Search our [airplay records](http://wxyc.info/playlists/searchPlaylists).
+Have a specific song, artist, album, or label in mind? Search our [airplay records](/airplay-search).


### PR DESCRIPTION
Closes #214. Last remaining code ticket in [Phase 4](https://github.com/WXYC/wiki/issues/91) of the [tubafrenzy decommissioning](https://github.com/orgs/WXYC/projects/36).

## Why now

tubafrenzy serves every `wxyc.info/playlists/*` page and goes dark at the 2026-08-31 cutover ([WXYC/wiki#93](https://github.com/WXYC/wiki/issues/93)), so the four listener-facing links from `wxyc.org` into `wxyc.info` become dead links on that date.

#214's two remaining blockers — #211 and #212 — both closed 2026-08-11, so all three successor pages are on `main`. Verified live in prod before repointing: `https://wxyc.org/playlist`, `/airplay-search`, and `/playlists/archive` each return 200.

## Changes

| Site | Was | Now |
|---|---|---|
| `components/Header.js:107` | `http://www.wxyc.info/playlists/recent` | `/playlist` (#211) |
| `components/DropdownMenu.js:49` | `http://www.wxyc.info/playlists/recent` | `/playlist` (#211) |
| `content/page/programming.mdx:54` | `http://wxyc.info/playlists/radioWeek` | `/playlists/archive` (#213) |
| `content/page/programming.mdx:56` | `http://wxyc.info/playlists/searchPlaylists` | `/airplay-search` (#212) |

Targets were read off `main`, not taken from the ticket's suggested filenames — `/airplay-search` is top-level, not under `/playlists/`.

Both nav links become internal navigations, so `target="_blank"` goes away and they take the repo's internal-link idiom (`legacyBehavior={false}`). Header's copy also gains `onClick={toggleMenu}`, matching every other internal link in that mobile overlay — without it the overlay stays open on top of the page it just navigated to. `DropdownMenu`'s stale `{/* Until new flowsheet is deployed: <Link href="/playlist"> */}` comment held exactly the target this PR now uses, so it is removed rather than left commenting on shipped code.

## Test

`__tests__/wxycInfoLinks.test.js` (8 assertions) guards the cutover: no `href` or markdown link anywhere in the repo may target `wxyc.info`; each of the four sites links to its named successor; each successor route resolves to a page that exists. **Verified red against the pre-change tree**, failing on all four sites.

It is a source-level check by choice, for two reasons a render test can't cover: `Header.js` and `DropdownMenu.js` hold JSX in `.js` files, which this repo's vitest transform rejects (`The JSX syntax extension is not currently enabled`), and the third site is TinaCMS-managed `.mdx` that no component test would reach.

## Notes for review

- **The `grep` acceptance criterion is met as narrowed on the ticket.** Three `wxyc.info` mentions survive — docblocks in the three successor pages, plus `README.md`. Each names the page it replaces. That is accurate provenance, not a link, and the ticket's own comment asks that it not be deleted to satisfy a grep. The test policies link targets only.
- **TinaCMS:** `content/page/programming.mdx` is CMS-managed. The edit is a plain body-text link swap in a file TinaCMS round-trips, so a later CMS edit should rewrite the file without conflict; nothing surprising surfaced. Worth watching on the next CMS save.
- **#93 ("Reconfigure top site nav", opened 2025-07-13)** proposes a broader nav restructure and still lists a "Recently Played" entry pointing at `wxyc.info`. Deliberately not implemented here. Its `wxyc.info` reference is now stale, but whether to close it as superseded is a human call.
- **Copy left alone:** `programming.mdx:54` still reads "going back to 2009", while the new archive page covers back to at least November 2004. Not corrected here — that is listener-facing copy, not a link.

## Verification

- `npm run test` — 287 passed (15 files)
- `npm run lint` — no errors (pre-existing `no-img-element` / `alt-text` warnings only)
- `npx next build` under `tinacms dev`, i.e. the exact CI build — succeeds; `/playlist`, `/airplay-search`, `/playlists/archive` all export, and the exported site contains **zero** `wxyc.info` occurrences
- `prettier --check` on all four touched files — clean. (`Header.js` and `DropdownMenu.js` were already prettier-dirty on `main` before this change; left as-is per the ticket.)